### PR TITLE
fix(hooks): add required top-level hooks key to hooks.json

### DIFF
--- a/plugins/python-dev/hooks/hooks.json
+++ b/plugins/python-dev/hooks/hooks.json
@@ -1,14 +1,16 @@
 {
-  "SessionStart": [
-    {
-      "matcher": "*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/setup-python-dev.sh",
-          "timeout": 10
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/setup-python-dev.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/workspace-setup/hooks/hooks.json
+++ b/plugins/workspace-setup/hooks/hooks.json
@@ -1,14 +1,16 @@
 {
-  "SessionStart": [
-    {
-      "matcher": "*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/setup-workspace.sh",
-          "timeout": 10
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/setup-workspace.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

- Both `python-dev` and `workspace-setup` `hooks.json` were missing the required `"hooks"` wrapper around event definitions
- Caused `"expected record, received undefined"` validation errors on plugin install
- Wraps `SessionStart` events under `{"hooks": {...}}` per schema spec

## Test plan

- [ ] Install `python-dev` plugin — no hooks errors
- [ ] Install `workspace-setup` plugin — no hooks errors

🤖 Generated with Claude <noreply@anthropic.com>