### PR TITLE
fix: remove duplicate hooks manifest references from 4 plugins

### DIFF
--- a/plugins/docs-generator/.claude-plugin/plugin.json
+++ b/plugins/docs-generator/.claude-plugin/plugin.json
@@ -3,6 +3,5 @@
   "version": "1.0.0",
   "description": "Document generation for writeups, tech specs (ADR/RFC/design docs), and reports with optional pandoc PDF export",
   "author": { "name": "Claude Code Utils Contributors" },
-  "keywords": ["docs", "writeup", "pandoc", "citations", "adr", "rfc", "design-doc", "report"],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["docs", "writeup", "pandoc", "citations", "adr", "rfc", "design-doc", "report"]
 }

--- a/plugins/python-dev/.claude-plugin/plugin.json
+++ b/plugins/python-dev/.claude-plugin/plugin.json
@@ -3,6 +3,5 @@
   "version": "1.0.0",
   "description": "Python implementation, testing, and code review skills, deploys uv permissions via SessionStart hook",
   "author": { "name": "Claude Code Utils Contributors" },
-  "keywords": ["python", "implementation", "testing", "review", "pytest"],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["python", "implementation", "testing", "review", "pytest"]
 }

--- a/plugins/workspace-sandbox/.claude-plugin/plugin.json
+++ b/plugins/workspace-sandbox/.claude-plugin/plugin.json
@@ -3,6 +3,5 @@
   "version": "1.0.0",
   "description": "Deploys workspace rules, statusline script, and sandbox settings via SessionStart hook",
   "author": { "name": "Claude Code Utils Contributors" },
-  "keywords": ["workspace", "settings", "rules", "statusline", "sandbox"],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["workspace", "settings", "rules", "statusline", "sandbox"]
 }

--- a/plugins/workspace-setup/.claude-plugin/plugin.json
+++ b/plugins/workspace-setup/.claude-plugin/plugin.json
@@ -3,6 +3,5 @@
   "version": "1.0.0",
   "description": "Deploys workspace rules, statusline script, and base settings via SessionStart hook",
   "author": { "name": "Claude Code Utils Contributors" },
-  "keywords": ["workspace", "settings", "rules", "statusline", "setup"],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["workspace", "settings", "rules", "statusline", "setup"]
 }


### PR DESCRIPTION
## Summary

- Remove explicit `"hooks": "./hooks/hooks.json"` from plugin.json manifests in 4 plugins: docs-generator, python-dev, workspace-sandbox, workspace-setup
- Claude Code auto-discovers `hooks/hooks.json` at the standard path — explicitly referencing it causes "Duplicate hooks file detected" errors
- Aligns with official Anthropic plugin patterns (security-guidance, hookify, ralph-loop, code-review all omit the hooks field)

## Root cause

Per [CC plugins-reference docs](https://code.claude.com/docs/en/plugins-reference): "Custom paths supplement default directories — they don't replace them." The standard `hooks/hooks.json` is always auto-loaded, so specifying it again in the manifest triggers a duplicate detection error.

## Test plan

- [ ] Restart Claude Code session — verify no "Duplicate hooks file detected" errors for these 4 plugins
- [ ] Verify SessionStart hooks still fire (check-prerequisites.sh, setup-workspace-sandbox.sh, etc.)
- [ ] Run `/plugin` and confirm all 4 plugins show Status: Enabled with 0 errors

Generated with Claude <noreply@anthropic.com>