### PR TITLE
ci: version bump enforcement + feat(embedded-dev): hooks and settings (#15)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
       "name": "embedded-dev",
       "source": "./plugins/embedded-dev",
       "description": "Embedded firmware development with CE/FCC compliance, ESP-IDF/PlatformIO, requirement traceability, and KiCad PCB auditing",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "name": "workspace-setup",

--- a/.claude/rules/plugin-versioning.md
+++ b/.claude/rules/plugin-versioning.md
@@ -1,0 +1,10 @@
+# Plugin Versioning
+
+When modifying any file under `plugins/<name>/`, you MUST:
+
+1. Bump that plugin's `version` in `plugins/<name>/.claude-plugin/plugin.json`
+2. Bump the matching `version` in `.claude-plugin/marketplace.json` for the same plugin
+3. Both versions MUST match
+
+This is required because installed plugins are cached — users won't receive
+fixes without a version bump.

--- a/.github/workflows/check-plugin-versions.yaml
+++ b/.github/workflows/check-plugin-versions.yaml
@@ -1,0 +1,68 @@
+name: Check Plugin Version Bumps
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "plugins/**"
+
+permissions:
+  contents: read
+
+jobs:
+  check-versions:
+    name: Verify changed plugins have version bumps
+    runs-on: ubuntu-latest
+    env:
+      BASE_REF: ${{ github.base_ref }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version bumps for changed plugins
+        shell: sh
+        run: |
+          set -eu
+
+          changed_plugins=$(
+            git diff --name-only "origin/$BASE_REF...HEAD" -- 'plugins/' |
+            cut -d'/' -f2 |
+            sort -u
+          )
+
+          if [ -z "$changed_plugins" ]; then
+            echo "No plugin directories changed."
+            exit 0
+          fi
+
+          errors=0
+          for plugin in $changed_plugins; do
+            manifest="plugins/$plugin/.claude-plugin/plugin.json"
+            if [ ! -f "$manifest" ]; then
+              continue
+            fi
+
+            # Check if plugin.json version changed vs base
+            if ! git diff "origin/$BASE_REF...HEAD" -- "$manifest" | grep -q '"version"'; then
+              echo "::error::Plugin '$plugin' has changes but no version bump in $manifest"
+              errors=$((errors + 1))
+              continue
+            fi
+
+            # Check marketplace.json has matching version
+            mp_version=$(jq -r --arg name "$plugin" '.plugins[] | select(.name == $name) | .version // empty' .claude-plugin/marketplace.json)
+            pj_version=$(jq -r '.version // empty' "$manifest")
+
+            if [ -n "$pj_version" ] && [ -n "$mp_version" ] && [ "$pj_version" != "$mp_version" ]; then
+              echo "::error::Plugin '$plugin' version mismatch: plugin.json=$pj_version, marketplace.json=$mp_version"
+              errors=$((errors + 1))
+            fi
+          done
+
+          if [ "$errors" -gt 0 ]; then
+            echo "::error::$errors plugin(s) need version bumps. See errors above."
+            exit 1
+          fi
+
+          echo "All changed plugins have version bumps."

--- a/plugins/embedded-dev/.claude-plugin/plugin.json
+++ b/plugins/embedded-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "embedded-dev",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Embedded firmware development with CE/FCC compliance, ESP-IDF/PlatformIO, requirement traceability, and KiCad PCB auditing",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["embedded", "firmware", "esp-idf", "platformio", "compliance", "misra", "kicad", "pcb", "traceability", "requirements"]

--- a/plugins/embedded-dev/README.md
+++ b/plugins/embedded-dev/README.md
@@ -20,6 +20,12 @@ checking-compliance → implementing-firmware → tracing-requirements
                       auditing-pcb-design (standalone)
 ```
 
+## SessionStart Hook
+
+On session start, if `gcc` is found in `$PATH` and `.claude/settings.local.json`
+does not exist, the plugin deploys embedded toolchain permissions (gcc, cppcheck,
+clang-tidy, clang-format, sqlite3, doxygen) via copy-if-not-exists.
+
 ## Install
 
 ```bash

--- a/plugins/embedded-dev/hooks/hooks.json
+++ b/plugins/embedded-dev/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/setup-embedded-dev.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/embedded-dev/hooks/scripts/setup-embedded-dev.sh
+++ b/plugins/embedded-dev/hooks/scripts/setup-embedded-dev.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+PLUGIN_DIR="$CLAUDE_PLUGIN_ROOT"
+deployed=0
+
+# Deploy embedded permissions to .claude/settings.local.json (copy-if-not-exists)
+if command -v gcc >/dev/null 2>&1; then
+  TARGET=".claude/settings.local.json"
+  if [ ! -f "$TARGET" ]; then
+    mkdir -p .claude
+    cp "$PLUGIN_DIR/settings/settings.local.json" "$TARGET"
+    deployed=$((deployed + 1))
+  fi
+fi
+
+# Report
+if [ "$deployed" -gt 0 ]; then
+  echo "# Embedded Dev Setup"
+  echo ""
+  echo "Deployed settings.local.json (embedded C toolchain permissions)"
+fi

--- a/plugins/embedded-dev/settings/settings.local.json
+++ b/plugins/embedded-dev/settings/settings.local.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gcc:*)",
+      "Bash(cppcheck:*)",
+      "Bash(clang-tidy:*)",
+      "Bash(clang-format:*)",
+      "Bash(sqlite3:*)",
+      "Bash(doxygen:*)",
+      "Edit(src/**)",
+      "Edit(test/**)",
+      "Edit(schema/**)",
+      "Edit(hw/**)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add Claude Code rule requiring version bumps when modifying plugin files
- Add GitHub Actions workflow that fails PRs without version bumps
- Add SessionStart hook and settings deployment to embedded-dev plugin (closes #15)

## Components

- `.claude/rules/plugin-versioning.md` — CC rule enforcing version bumps
- `.github/workflows/check-plugin-versions.yaml` — CI check (POSIX sh)
- `plugins/embedded-dev/hooks/` — SessionStart hook + POSIX setup script
- `plugins/embedded-dev/settings/` — C toolchain permissions
- Version bump: embedded-dev 1.0.0 → 1.1.0

## Test plan

- [x] Hook tested locally: deploys settings on first run, silent on second (idempotent)
- [x] POSIX sh — no bashisms
- [x] No hooks field in plugin.json (auto-discovery)
- [ ] CI workflow: modify plugin without version bump → should fail

Generated with Claude <noreply@anthropic.com>