### PR TITLE
docs: sync README and CHANGELOG with merged PRs #16-26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **cc-meta**: `synthesizing-cc-bigpicture` — project filter param (`[project-name] [time-range] [output-path]`), usage examples
+- **market-research**: New plugin with 8 skills — GTM pipeline with teams mode parallel dispatch, 2x2 strategy matrix, contradiction analysis, slide deck generation
+- **python-dev**: Scaffold adapter for Ralph loop (`scaffold/adapter.sh`, project templates, GHA workflows)
+- **embedded-dev**: Scaffold adapter with `find -print0 | xargs -0` safe filenames
+- **cc-meta**: `synthesizing-cc-bigpicture` skill — project filter param (`[project-name] [time-range] [output-path]`), usage examples
 - **cc-meta**: Auto-resolve output path — project-filtered runs write to `<project>/docs/bigpicture.md`, unfiltered to `~/.claude/bigpicture.md`
 - **cc-meta**: Project-Arching TODOs & DONEs output section (from roadmap.md, CHANGELOG.md, AGENT_REQUESTS.md)
 - **cc-meta**: `stats-cache.json` and `history.jsonl` as data sources for activity trajectory and session discovery
 - **cc-meta**: Team inbox parsing (`teams/*/inboxes/*.json`) and subagent transcript paths
-- Root README: cc-meta row in Plugins table (was missing), plugin count 11 → 12, skill count 21 → 22
+- `examples/memory/`: MEMORY.md and claude-cowork-api.md example templates
+- `CODEOWNERS`: skill file ownership for content protection
+- `scaffolds.json`: scaffold registry for python-dev and embedded-dev
+- CI: `check-skill-integrity.yaml` + `compute-skill-hashes.sh` for content-hash skill protection
+- CI: `research-monitor` GHA for tracking upstream CC changes (#19)
+- Root README: cc-meta and market-research rows in Plugins table, plugin count 12 → 13, skill count 22 → 31
 
 ### Fixed
 
@@ -27,10 +35,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **cc-meta**: `cc-entry-types.md` reference rewritten with accurate schemas and examples
 - **cc-meta**: Frontmatter aligned to agentskills.io conventions (`argument-hint` kebab-case, `Target` not `Query`)
 - **cc-meta**: Project filter now applies to global sources (plans, tasks, teams) — plans filtered by content grep, tasks/teams by session allowlist correlation. Previously these leaked unfiltered data from all projects.
+- Removed duplicate hooks manifest references from 4 plugins (#16)
+- **embedded-dev**: `find -print0 | xargs -0` for safe filenames in scaffold adapter
 
 ### Changed
 
 - **cc-meta**: Plugin version 1.0.0 → 1.1.0
+- **embedded-dev**: Plugin version 1.0.1 → 1.2.0 (scaffold adapter + hooks/settings)
+- All plugins: stability metadata added to plugin.json via version bumps
+- **commit-helper**: Synced SKILL.md with latest conventions (#19)
+- Renamed `claude-code-research` references to `coding-agents-research` (#21)
 
 ## [3.0.0] - 2026-03-01
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # qte77-claude-code-utils
 
-Claude Code plugin marketplace — 12 plugins, 22 skills from production workflows.
+Claude Code plugin marketplace — 13 plugins, 31 skills from production workflows.
 
 [![License](https://img.shields.io/badge/license-BSD3Clause-58f4c2.svg)](LICENSE.md)
 ![Version](https://img.shields.io/badge/version-3.0.0-58f4c2.svg)
@@ -27,7 +27,7 @@ Claude Code plugin marketplace — 12 plugins, 22 skills from production workflo
 # 1. Add the marketplace
 claude plugin marketplace add qte77/claude-code-utils-plugin
 
-# 2. Install all 12 plugins (pick ONE workspace plugin)
+# 2. Install all 13 plugins (pick ONE workspace plugin)
 claude plugin install python-dev@qte77-claude-code-utils
 claude plugin install commit-helper@qte77-claude-code-utils
 claude plugin install codebase-tools@qte77-claude-code-utils
@@ -38,6 +38,7 @@ claude plugin install docs-generator@qte77-claude-code-utils
 claude plugin install ralph@qte77-claude-code-utils
 claude plugin install embedded-dev@qte77-claude-code-utils
 claude plugin install cc-meta@qte77-claude-code-utils
+claude plugin install market-research@qte77-claude-code-utils
 claude plugin install workspace-setup@qte77-claude-code-utils    # OR workspace-sandbox
 
 # 3. Verify
@@ -57,9 +58,10 @@ claude plugin list
 | **mas-design** | `designing-mas-plugins` `securing-mas` | Multi-agent plugin design + OWASP MAESTRO |
 | **website-audit** | `researching-website-design` `auditing-website-usability` `auditing-website-accessibility` | Design research, UX audit, WCAG 2.1 AA |
 | **docs-generator** | `generating-writeup` `generating-tech-spec` `generating-report` | Writeups, tech specs (ADR/RFC/design docs), reports |
-| **ralph** | `generating-prd-json-from-prd-md` `generating-interactive-userstory-md` | PRD-to-JSON, interactive user stories |
+| **ralph** | `generating-prd-json-from-prd-md` `generating-interactive-userstory-md` `generating-prd-md-from-userstory-md` | PRD-to-JSON, interactive user stories, PRD generation |
 | **embedded-dev** | `checking-compliance` `implementing-firmware` `tracing-requirements` `auditing-pcb-design` | CE/FCC compliance, ESP-IDF/PlatformIO, requirement traceability, KiCad PCB audit |
 | **cc-meta** | `synthesizing-cc-bigpicture` | Cross-project synthesis from `~/.claude/` artifacts (sessions, plans, tasks, teams) |
+| **market-research** | `researching-market` `researching-industry-landscape` `analyzing-source-project` `analyzing-contradictions` `synthesizing-research` `validating-product-market-fit` `developing-gtm-strategy` `generating-slide-deck` | GTM pipeline with teams mode, 2x2 strategy matrix, contradiction analysis |
 | **workspace-setup** | — | Deploys rules, statusline, and base settings via SessionStart hook |
 | **workspace-sandbox** | — | Deploys rules, statusline, sandbox settings, and .gitignore via SessionStart hook |
 


### PR DESCRIPTION
## Summary
- **README**: Add market-research plugin row (8 skills), ralph 3rd skill, update counts 12→13 plugins / 22→31 skills, add install command
- **CHANGELOG**: Add missing entries for PRs #16-21 (scaffold plugins, skill protection CI, embedded-dev hooks, research-monitor GHA, duplicate hooks fix, repo rename)

## Test plan
- [x] Verified plugin count (13) and skill count (31) match actual files on disk
- [x] Cross-referenced git log against CHANGELOG entries — all merged PRs now covered

Generated with Claude <noreply@anthropic.com>