### PR TITLE
fix: license badge, LICENSE link, stale marketplace description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "qte77"
   },
   "metadata": {
-    "description": "Claude Code utility plugins for Python development, architecture, auditing, and documentation workflows",
+    "description": "Claude Code utility plugins for development, architecture, auditing, documentation, market research, and CC meta-skills",
     "version": "1.0.0"
   },
   "plugins": [
@@ -59,7 +59,7 @@
     {
       "name": "ralph",
       "source": "./plugins/ralph",
-      "description": "PRD-to-JSON conversion and interactive user story builder for the Ralph loop",
+      "description": "PRD-to-JSON conversion, interactive user story builder, and PRD generation for the Ralph loop",
       "version": "1.0.1"
     },
     {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Claude Code plugin marketplace — 13 plugins, 31 skills from production workflows.
 
-[![License](https://img.shields.io/badge/license-BSD3Clause-58f4c2.svg)](LICENSE.md)
+[![License](https://img.shields.io/badge/license-MIT-58f4c2.svg)](LICENSE)
 ![Version](https://img.shields.io/badge/version-3.0.0-58f4c2.svg)
 [![CodeQL](https://github.com/qte77/claude-code-utils-plugin/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/claude-code-utils-plugin/actions/workflows/codeql.yaml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/claude-code-utils-plugin/badge/main)](https://www.codefactor.io/repository/github/qte77/claude-code-utils-plugin/overview/main)


### PR DESCRIPTION
## Summary
- License badge: `BSD3Clause` → `MIT` (matches actual LICENSE file)
- Badge link: `LICENSE.md` → `LICENSE` (file has no .md extension)
- Marketplace metadata description: added market research, CC meta-skills, embedded dev
- Ralph plugin description: added 3rd skill (PRD generation)

## Test plan
- [x] LICENSE file confirmed as MIT
- [x] Badge link resolves to correct file

Generated with Claude <noreply@anthropic.com>