### PR TITLE
fix: marketplace metadata version 1.0.0 → 3.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code utility plugins for development, architecture, auditing, documentation, market research, and CC meta-skills",
-    "version": "1.0.0"
+    "version": "3.0.0"
   },
   "plugins": [
     {


### PR DESCRIPTION
## Summary
- Marketplace `metadata.version` was `1.0.0`, should be `3.0.0` to match repo release version (README badge)
- Marketplace version = repo release version. Individual plugin versions are independent.

Generated with Claude <noreply@anthropic.com>