### PR TITLE
feat: add compound-learning rule to workspace plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,13 +72,13 @@
       "name": "workspace-setup",
       "source": "./plugins/workspace-setup",
       "description": "Deploys workspace rules, statusline script, and base settings via SessionStart hook",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "name": "workspace-sandbox",
       "source": "./plugins/workspace-sandbox",
       "description": "Deploys workspace rules, statusline script, and sandbox settings via SessionStart hook",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "name": "market-research",

--- a/plugins/cc-meta/README.md
+++ b/plugins/cc-meta/README.md
@@ -5,6 +5,7 @@ Claude Code meta-skills for cross-project synthesis and session intelligence.
 ## Skills
 
 - **synthesizing-cc-bigpicture** — Synthesizes a living meta-plan across Claude Code sessions, plans, tasks, and team communications. Surfaces reasoning modes (diverge/converge, inductive/deductive, top-down/bottom-up) per work stream and project-arching TODOs/DONEs.
+- **compacting-context** — Distills verbose outputs into structured summaries following ACE-FCA principles. Use after pollution sources (searches, logs, JSON) or at phase milestones.
 
 ## Usage
 

--- a/plugins/workspace-sandbox/.claude-plugin/plugin.json
+++ b/plugins/workspace-sandbox/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-sandbox",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Deploys workspace rules, statusline script, and sandbox settings via SessionStart hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "sandbox"]

--- a/plugins/workspace-sandbox/rules/compound-learning.md
+++ b/plugins/workspace-sandbox/rules/compound-learning.md
@@ -1,0 +1,21 @@
+# Compound Learning
+
+Prevent repeated mistakes by systematically promoting learnings.
+
+## Before Solving a Problem
+
+Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
+
+## Promotion Path
+
+1. **1st occurrence** — fix inline, move on
+2. **2nd occurrence** — add to AGENT_LEARNINGS.md (pattern + solution)
+3. **3rd occurrence** — promote to `.claude/rules/` (always-loaded, prevents recurrence)
+4. **Recurring workflow** — extract to `.claude/skills/` (reusable capability)
+
+## When Promoting (step 3)
+
+- Verify the root cause is the same across occurrences
+- Write the rule as a constraint ("do X", "never Y"), not a narrative
+- Reference the AGENT_LEARNINGS.md entry being promoted
+- Remove or link the original entry to avoid duplication

--- a/plugins/workspace-setup/.claude-plugin/plugin.json
+++ b/plugins/workspace-setup/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-setup",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Deploys workspace rules, statusline script, and base settings via SessionStart hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "setup"]

--- a/plugins/workspace-setup/rules/compound-learning.md
+++ b/plugins/workspace-setup/rules/compound-learning.md
@@ -1,0 +1,21 @@
+# Compound Learning
+
+Prevent repeated mistakes by systematically promoting learnings.
+
+## Before Solving a Problem
+
+Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
+
+## Promotion Path
+
+1. **1st occurrence** — fix inline, move on
+2. **2nd occurrence** — add to AGENT_LEARNINGS.md (pattern + solution)
+3. **3rd occurrence** — promote to `.claude/rules/` (always-loaded, prevents recurrence)
+4. **Recurring workflow** — extract to `.claude/skills/` (reusable capability)
+
+## When Promoting (step 3)
+
+- Verify the root cause is the same across occurrences
+- Write the rule as a constraint ("do X", "never Y"), not a narrative
+- Reference the AGENT_LEARNINGS.md entry being promoted
+- Remove or link the original entry to avoid duplication


### PR DESCRIPTION
## Summary

- Add compound-learning rule (rule-of-three promotion path) to workspace-setup and workspace-sandbox plugins
- Bump workspace-setup and workspace-sandbox to 1.1.0
- Update cc-meta README to list compacting-context skill

## Compound Learning Rule

Promotion path for preventing repeated mistakes:
1. 1st occurrence — fix inline
2. 2nd occurrence — AGENT_LEARNINGS.md
3. 3rd occurrence — `.claude/rules/` (always-loaded)
4. Recurring workflow — `.claude/skills/`

Generated with Claude <noreply@anthropic.com>