### PR TITLE
chore: standardize repo scaffold

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,10 +5,19 @@
   },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
-    "plugin-dev@claude-plugins-official": true
+    "plugin-dev@claude-plugins-official": true,
+    "commit-helper@qte77-claude-code-utils": true
+  },
+  "extraKnownMarketplaces": {
+    "qte77-claude-code-utils": {
+      "source": {
+        "source": "github",
+        "repo": "qte77/claude-code-utils-plugin"
+      }
+    }
   },
   "attribution": {
-    "commit": "🤖 Co-Authored-By: Claude <noreply@anthropic.com>",
-    "pr": "🤖 Generated with Claude <noreply@anthropic.com>"
+    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
+    "pr": "Generated with Claude <noreply@anthropic.com>"
   }
 }

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a problem
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+
+1. Run `...`
+2. ...
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened. Include error traces if applicable -->
+
+## Environment
+
+- OS/Runner:
+- Version:
+
+## Additional Context
+
+<!-- Screenshots, logs, related issues, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,15 @@
+---
+name: Question
+about: Ask a question not covered by the documentation
+title: ''
+labels: question
+assignees: ''
+---
+
+**Have you checked the docs?**
+
+- [ ] README.md
+
+## Question
+
+<!-- Your question here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+# Summary
+
+<!-- Brief description of what this PR does and why -->
+
+Closes <!-- #issue-number or N/A -->
+
+## Type of Change
+
+<!-- Check all that apply. Commit type must match conventional commits: feat|fix|build|chore|ci|docs|style|refactor|perf|revert|test -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `refactor` — no functional change
+- [ ] `test` — test additions or fixes
+- [ ] `ci` — CI/CD changes
+- [ ] `build` — build system or dependency changes
+- [ ] `perf` — performance improvement
+- [ ] `style` — formatting, whitespace (no logic change)
+- [ ] `revert` — reverts a previous commit
+- [ ] `chore` — tooling, config, maintenance
+- [ ] **Breaking change** — add `!` after commit type
+
+## Self-Review
+
+- [ ] I have reviewed my own diff and removed debug/dead code
+- [ ] Commit messages follow conventional commits format
+
+## Testing
+
+- [ ] Tests pass locally
+- [ ] CI workflows pass
+
+## Security
+
+- [ ] No hardcoded secrets, API keys, or credentials
+- [ ] No new injection vectors in workflow `run:` steps

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,4 +1,5 @@
-name: "CodeQL"
+---
+name: CodeQL
 
 on:
   push:
@@ -6,19 +7,21 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: "27 11 * * 0"
+    - cron: '0 6 * * 1'
   workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
 
 jobs:
   analyze:
-    name: Analyze
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
     steps:
       - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+      - uses: github/codeql-action/autobuild@v4
+      - uses: github/codeql-action/analyze@v4

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/qte77/claude-code-utils-plugin/security/advisories/new).
+
+Do not open a public issue for security vulnerabilities.


### PR DESCRIPTION
## Summary

Standardize repository scaffold to match the qte77 org-wide pattern.

## Changes

- `.gitmessage` — conventional commits template
- `.claude/settings.json` — attribution config + commit-helper plugin from `qte77/claude-code-utils-plugin`
- `SECURITY.md` — GitHub Security Advisories reporting link
- `.github/PULL_REQUEST_TEMPLATE.md` — conventional commits PR checklist
- `.github/ISSUE_TEMPLATE/` — bug report + question templates
- CodeQL workflow (where applicable for repo language)
- Dependabot config (where applicable for repo ecosystem)
- `LICENSE` (BSD-3-Clause, where missing)
- `.gitignore` (where missing)

Generated with Claude <noreply@anthropic.com>