### PR TITLE
feat(go-dev): add Go development plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code utility plugins for development, architecture, auditing, documentation, market research, and CC meta-skills",
-    "version": "3.0.0"
+    "version": "3.1.0"
   },
   "plugins": [
     {
@@ -84,6 +84,12 @@
       "name": "market-research",
       "source": "./plugins/market-research",
       "description": "GTM market research pipeline with teams mode parallel dispatch and configurable 2x2 strategy matrix",
+      "version": "1.0.0"
+    },
+    {
+      "name": "go-dev",
+      "source": "./plugins/go-dev",
+      "description": "Go implementation, testing, code review skills, and scaffold adapter for Ralph loop",
       "version": "1.0.0"
     }
   ]

--- a/plugins/go-dev/.claude-plugin/plugin.json
+++ b/plugins/go-dev/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "go-dev",
+  "version": "1.0.0",
+  "description": "Go implementation, testing, code review skills, and scaffold adapter for Ralph loop",
+  "author": { "name": "Claude Code Utils Contributors" },
+  "keywords": ["go", "golang", "implementation", "testing", "review", "golangci-lint"]
+}

--- a/plugins/go-dev/README.md
+++ b/plugins/go-dev/README.md
@@ -1,0 +1,37 @@
+# go-dev
+
+Go implementation, testing, and code review skills with scaffold adapter for
+the Ralph loop.
+
+## Skills
+
+| Skill | Trigger |
+|-------|---------|
+| `implementing-go` | Writing Go code, creating packages, implementing features |
+| `testing-go` | Writing tests, TDD, table-driven tests, fuzz testing, benchmarks |
+| `reviewing-go` | Code review for quality, security, idiomatic style |
+
+## Scaffold Adapter
+
+Provides Go-specific implementations of the Ralph loop adapter interface:
+
+- `_scaffold_test()` — `go test -race -count=1 ./...`
+- `_scaffold_lint()` — `golangci-lint run` (fallback: `go vet` + `gofmt`)
+- `_scaffold_typecheck()` — `go vet ./...`
+- `_scaffold_complexity()` — `gocyclo -over 15`
+- `_scaffold_coverage()` — `go test -coverprofile=coverage.out ./...`
+- `_scaffold_validate()` — `make validate` or lint+typecheck+test sequence
+
+## CI Workflow Templates
+
+Deployed to `.github/workflows/` when `.scaffold == "go"`:
+
+- `go-test.yaml` — tests with race detector and coverage
+- `golangci-lint.yaml` — linting via golangci-lint-action v6
+- `govulncheck.yaml` — vulnerability scanning
+- `dependabot.yaml` — automated Go module updates
+
+## Settings
+
+Grants Bash permissions for: `go build`, `go test`, `go vet`, `go mod`,
+`go generate`, `golangci-lint`, `govulncheck`.

--- a/plugins/go-dev/hooks/hooks.json
+++ b/plugins/go-dev/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/setup-go-dev.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/go-dev/hooks/scripts/setup-go-dev.sh
+++ b/plugins/go-dev/hooks/scripts/setup-go-dev.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+PLUGIN_DIR="$CLAUDE_PLUGIN_ROOT"
+SCAFFOLD_DIR="$PLUGIN_DIR/scaffold"
+DEPLOYED=()
+
+# Deploy Go toolchain permissions to .claude/settings.local.json (copy-if-not-exists)
+if command -v go >/dev/null 2>&1; then
+  TARGET=".claude/settings.local.json"
+  if [ ! -f "$TARGET" ]; then
+    mkdir -p .claude
+    cp "$PLUGIN_DIR/settings/settings.local.json" "$TARGET"
+    DEPLOYED+=("settings: settings.local.json (go permissions)")
+  fi
+fi
+
+# Deploy scaffold adapter (copy-if-not-exists, gated on .scaffold == "go")
+if [ -f ".scaffold" ] && [ "$(cat .scaffold 2>/dev/null)" = "go" ]; then
+  # Adapter script for Ralph Loop
+  mkdir -p .scaffolds
+  if [ ! -f ".scaffolds/go.sh" ]; then
+    cp "$SCAFFOLD_DIR/adapter.sh" ".scaffolds/go.sh"
+    DEPLOYED+=("scaffold: .scaffolds/go.sh (Ralph adapter)")
+  fi
+
+  # Testing rule (copy-if-not-exists)
+  if [ -d "$SCAFFOLD_DIR/rules" ]; then
+    mkdir -p .claude/rules
+    for rule_file in "$SCAFFOLD_DIR/rules/"*.md; do
+      [ -f "$rule_file" ] || continue
+      local_name=".claude/rules/$(basename "$rule_file")"
+      if [ ! -f "$local_name" ]; then
+        cp "$rule_file" "$local_name"
+        DEPLOYED+=("rule: $(basename "$rule_file")")
+      fi
+    done
+  fi
+
+  # CI workflows (copy-if-not-exists)
+  if [ -d "$SCAFFOLD_DIR/workflows" ]; then
+    mkdir -p .github/workflows
+    for wf_file in "$SCAFFOLD_DIR/workflows/"*.yaml; do
+      [ -f "$wf_file" ] || continue
+      local_name=".github/workflows/$(basename "$wf_file")"
+      if [ ! -f "$local_name" ]; then
+        cp "$wf_file" "$local_name"
+        DEPLOYED+=("workflow: $(basename "$wf_file")")
+      fi
+    done
+  fi
+
+  # Dependabot config (copy-if-not-exists)
+  if [ -f "$SCAFFOLD_DIR/workflows/dependabot.yaml" ] && [ ! -f ".github/dependabot.yaml" ]; then
+    cp "$SCAFFOLD_DIR/workflows/dependabot.yaml" ".github/dependabot.yaml"
+    DEPLOYED+=("config: dependabot.yaml")
+  fi
+fi
+
+# Report
+if [ ${#DEPLOYED[@]} -gt 0 ]; then
+  echo "# Go Dev Setup"
+  echo ""
+  echo "Deployed ${#DEPLOYED[@]} file(s):"
+  for item in "${DEPLOYED[@]}"; do
+    echo "  - $item"
+  done
+fi

--- a/plugins/go-dev/scaffold/adapter.sh
+++ b/plugins/go-dev/scaffold/adapter.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+# Go scaffold adapter for Ralph Loop
+# Deployed to .scaffolds/go.sh by go-dev plugin hook.
+# Provides Go-specific implementations of adapter_* interface.
+#
+# Tools: go, golangci-lint, gocyclo (optional)
+#
+
+# Run tests. Output includes "FAIL" lines for baseline comparison.
+_scaffold_test() {
+    if [ $# -gt 0 ]; then
+        go test -race -count=1 -v "$@"
+    else
+        go test -race -count=1 ./...
+    fi
+}
+
+# Lint source files with golangci-lint (fallback to go vet + gofmt).
+_scaffold_lint() {
+    if command -v golangci-lint >/dev/null 2>&1; then
+        if [ $# -gt 0 ]; then
+            golangci-lint run "$@"
+        else
+            golangci-lint run ./...
+        fi
+    else
+        go vet ./...
+        gofmt -l .
+    fi
+}
+
+# Static type/correctness checking with go vet.
+_scaffold_typecheck() {
+    go vet ./...
+}
+
+# Cyclomatic complexity analysis (requires gocyclo).
+_scaffold_complexity() {
+    if command -v gocyclo >/dev/null 2>&1; then
+        if [ $# -gt 0 ]; then
+            gocyclo -over 15 "$@"
+        else
+            gocyclo -over 15 .
+        fi
+    else
+        echo "gocyclo not installed, skipping complexity check"
+    fi
+}
+
+# Run tests with coverage. Output includes coverage percentage.
+_scaffold_coverage() {
+    go test -coverprofile=coverage.out ./...
+    go tool cover -func=coverage.out
+}
+
+# Full validation sequence.
+_scaffold_validate() {
+    if [ -f Makefile ] && make -n validate >/dev/null 2>&1; then
+        make validate
+    else
+        _scaffold_lint
+        _scaffold_typecheck
+        _scaffold_test
+    fi
+}
+
+# Extract function/type signatures from a Go file.
+_scaffold_signatures() {
+    local filepath="$1"
+    grep -nE "^(func |type |var |const )" "$filepath" 2>/dev/null || true
+}
+
+# Glob pattern for Go source files.
+_scaffold_file_pattern() {
+    echo "*.go"
+}
+
+# Set up Go environment.
+_scaffold_env_setup() {
+    export CGO_ENABLED=0
+}
+
+# Generate Go-specific application docs.
+_scaffold_app_docs() {
+    local src_dir="$1"
+    local app_name
+    app_name=$(basename "$src_dir")
+    local example_path="$src_dir/example_test.go"
+
+    cat > "$example_path" <<GOEOF
+package ${app_name}_test
+
+import (
+    "fmt"
+)
+
+func Example() {
+    // TODO: Add your example usage here
+    fmt.Println("Example: Running $app_name")
+    // Output: Example: Running $app_name
+}
+GOEOF
+}

--- a/plugins/go-dev/scaffold/rules/testing.md
+++ b/plugins/go-dev/scaffold/rules/testing.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - "**/*_test.go"
+---
+
+# Go Testing Rules
+
+- Table-driven tests with descriptive names in `t.Run()`
+- Compare errors with `errors.Is`/`errors.As`, not `==`
+- Use `t.Helper()` in test helper functions
+- Use `t.Parallel()` only when tests have no shared mutable state
+- Use `t.TempDir()` for filesystem isolation, `testdata/` for fixtures
+- Always run with `-race` flag in CI

--- a/plugins/go-dev/scaffold/workflows/dependabot.yaml
+++ b/plugins/go-dev/scaffold/workflows/dependabot.yaml
@@ -1,0 +1,9 @@
+---
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+...

--- a/plugins/go-dev/scaffold/workflows/go-test.yaml
+++ b/plugins/go-dev/scaffold/workflows/go-test.yaml
@@ -1,0 +1,26 @@
+name: go-test
+permissions:
+  contents: read
+on:
+  push:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Verify dependencies
+        run: go mod verify
+      - name: Run tests
+        run: go test -race -coverprofile=coverage.out -count=1 ./...
+      - name: Coverage summary
+        run: go tool cover -func=coverage.out

--- a/plugins/go-dev/scaffold/workflows/golangci-lint.yaml
+++ b/plugins/go-dev/scaffold/workflows/golangci-lint.yaml
@@ -1,0 +1,24 @@
+name: golangci-lint
+permissions:
+  contents: read
+on:
+  push:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.1.0

--- a/plugins/go-dev/scaffold/workflows/govulncheck.yaml
+++ b/plugins/go-dev/scaffold/workflows/govulncheck.yaml
@@ -1,0 +1,24 @@
+name: govulncheck
+permissions:
+  contents: read
+on:
+  push:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+jobs:
+  vulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/plugins/go-dev/settings/settings.local.json
+++ b/plugins/go-dev/settings/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go build:*)",
+      "Bash(go test:*)",
+      "Bash(go vet:*)",
+      "Bash(go mod:*)",
+      "Bash(go generate:*)",
+      "Bash(golangci-lint:*)",
+      "Bash(govulncheck:*)"
+    ]
+  }
+}

--- a/plugins/go-dev/skills/implementing-go/SKILL.md
+++ b/plugins/go-dev/skills/implementing-go/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: implementing-go
+description: Implements idiomatic Go code matching architect specifications. Use when writing Go code, creating packages, or implementing features in Go.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, Edit, Write, Bash, WebSearch, WebFetch
+  argument-hint: [feature-name]
+  stability: stable
+  content-hash: sha256:placeholder
+  last-verified-cc-version: 2.1.0
+---
+
+# Go Implementation
+
+**Target**: $ARGUMENTS
+
+Creates **focused, idiomatic** Go implementations following specifications
+exactly. No over-engineering.
+
+## Go Standards
+
+See `references/go-best-practices.md` for comprehensive Go guidelines.
+
+## Workflow
+
+1. **Read specifications** from provided documents
+2. **Validate scope** — Simple (single package) vs Complex (multi-package)
+3. **Study existing patterns** in project structure
+4. **Implement minimal solution** matching stated functionality
+5. **Create focused tests** matching task complexity
+6. **Run validation** and fix all issues
+
+## Implementation Strategy
+
+**Simple Tasks**: Single-package functions, standard error handling,
+table-driven tests
+
+**Complex Tasks**: Multi-package with `internal/`, custom error types,
+interface-based design, comprehensive test coverage
+
+**Always**: Use existing project patterns, pass `go vet` and `go test -race`
+
+## Output Standards
+
+**Simple Tasks**: Minimal Go functions with proper error returns
+**Complex Tasks**: Complete packages with interfaces, tests, godoc
+**All outputs**: Idiomatic, concise, no unnecessary abstraction
+
+## Quality Checks
+
+Before completing any task:
+
+```bash
+go vet ./...
+go test -race ./...
+golangci-lint run ./...
+```
+
+All checks must pass.

--- a/plugins/go-dev/skills/implementing-go/references/go-best-practices.md
+++ b/plugins/go-dev/skills/implementing-go/references/go-best-practices.md
@@ -1,0 +1,63 @@
+# Go Best Practices Reference
+
+## Naming
+
+- **Packages**: short, lowercase, singular, no underscores (`user`, `auth`, `http`)
+- **Exported**: PascalCase (`ValidateUser`, `ErrNotFound`)
+- **Unexported**: camelCase (`writeToDB`, `maxRetries`)
+- **Acronyms**: all caps (`userID`, `httpClient`, `parseURL`)
+- **Receivers**: 1-2 letters matching type (`u` for `User`, `c` for `Client`)
+- **Interfaces**: single-method with `-er` suffix (`Reader`, `Writer`)
+- **Constants**: PascalCase exported, camelCase unexported (never `ALL_CAPS`)
+- **Files**: lowercase with underscores (`user_service.go`)
+- **Errors**: prefix `Err` for sentinels, suffix `Error` for types
+
+## Error Handling
+
+| Situation | Pattern |
+|-----------|---------|
+| Caller must branch on condition | Sentinel error + `errors.Is` |
+| Error needs structured data | Custom type + `errors.As` |
+| Adding context at boundary | `fmt.Errorf("context: %w", err)` |
+| Simple message, no inspection | `errors.New(...)` |
+
+Rules:
+- Always use `%w` (not `%v`) when callers need `errors.Is`/`errors.As`
+- Wrap at abstraction boundaries, not within the same layer
+- Error strings: lowercase, no trailing punctuation
+- Never discard errors with `_` in production code
+- Never `panic` for normal error flow
+
+## Project Layout
+
+```
+cmd/           # Thin main.go per binary (~50 lines max)
+internal/      # Private packages (compiler-enforced)
+pkg/           # Public reusable packages (deliberate commitment)
+api/           # OpenAPI specs, protobuf definitions
+testdata/      # Test fixtures (ignored by go build)
+```
+
+Dependency direction: `cmd/` → `internal/` → `pkg/`
+
+## Context
+
+- `context.Context` is always the first parameter
+- Variable name is always `ctx`
+- Never store context in a struct
+
+## Style
+
+- `gofmt` is non-negotiable; prefer `gofumpt` for stricter formatting
+- Early returns (guard clauses) over nested `if/else`
+- `goimports` for import grouping: stdlib, then third-party
+- Comments explain *why*, not *what*
+- Exported identifiers must have doc comments starting with the identifier name
+
+## Security
+
+- Passwords: `bcrypt` (cost >= 12) or Argon2id
+- Random values: `crypto/rand`, never `math/rand`
+- TLS: minimum 1.2, prefer 1.3
+- SSRF: validate URLs, block private IP ranges, allowlist domains
+- SQL: parameterized queries only

--- a/plugins/go-dev/skills/reviewing-go/SKILL.md
+++ b/plugins/go-dev/skills/reviewing-go/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: reviewing-go
+description: Provides focused Go code reviews for quality, security, and idiomatic style. Use when reviewing Go code or when the user asks for code review.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, WebFetch, WebSearch
+  argument-hint: [file-or-directory]
+  stability: stable
+  content-hash: sha256:placeholder
+  last-verified-cc-version: 2.1.0
+---
+
+# Review Context
+
+- Changed files: !`git diff --name-only HEAD~1 2>/dev/null || echo "No recent commits"`
+- Staged files: !`git diff --staged --name-only`
+
+## Go Code Review
+
+**Scope**: $ARGUMENTS
+
+Delivers **focused, idiomatic** Go code reviews matching stated task
+requirements exactly. No over-analysis.
+
+## Go Standards
+
+See `references/go-review-checklist.md` for comprehensive review guidelines.
+
+## Workflow
+
+1. **Read task requirements** to understand expected scope
+2. **Check `go vet` and `go test -race`** pass before detailed review
+3. **Match review depth** to task complexity
+4. **Validate requirements** — does implementation match task scope exactly?
+5. **Issue focused feedback** with specific file paths and line numbers
+
+## Review Strategy
+
+**Simple Tasks**: Security, error handling correctness, naming, requirements
+match
+
+**Complex Tasks**: Above plus architecture, interface design, concurrency
+safety, performance
+
+**Always**: Check error wrapping, naming conventions, test coverage
+
+## Review Checklist
+
+**Security & Correctness**:
+
+- [ ] No security vulnerabilities (SSRF, injection, path traversal)
+- [ ] `crypto/rand` not `math/rand` for security values
+- [ ] Errors wrapped with `%w` at boundaries, checked with `errors.Is`/`errors.As`
+- [ ] `go vet` and `go test -race` pass
+
+**Idiomatic Go**:
+
+- [ ] Naming follows Go conventions (PascalCase exports, camelCase internal)
+- [ ] Acronyms all-caps (`ID`, `URL`, `HTTP`)
+- [ ] `context.Context` as first parameter
+- [ ] Interfaces are small (1-2 methods)
+- [ ] Early returns over nested `if/else`
+
+**Code Quality**:
+
+- [ ] Implements exactly what was requested
+- [ ] No over-engineering or scope creep
+- [ ] Tests cover stated functionality with table-driven pattern
+
+**Structural Health**:
+
+- [ ] No function exceeds cyclomatic complexity 15
+- [ ] No copy-paste duplication across methods
+- [ ] Package names are descriptive (no `utils`, `common`, `helpers`)
+
+## Output Standards
+
+**Simple Tasks**: CRITICAL issues only, clear approval when requirements met
+**Complex Tasks**: CRITICAL/WARNINGS/SUGGESTIONS with specific fixes
+**All reviews**: Concise, actionable, no unnecessary analysis

--- a/plugins/go-dev/skills/reviewing-go/references/go-review-checklist.md
+++ b/plugins/go-dev/skills/reviewing-go/references/go-review-checklist.md
@@ -1,0 +1,66 @@
+# Go Review Checklist Reference
+
+## Recommended golangci-lint Linters
+
+```yaml
+version: "2"
+linters:
+  enable:
+    - errcheck       # Unchecked errors
+    - govet          # go vet checks
+    - staticcheck    # Deep static analysis
+    - gosimple       # Code simplification
+    - ineffassign    # Ineffectual assignments
+    - unused         # Unused code
+    - revive         # Style linting (replaces golint)
+    - gosec          # Security checks
+    - goimports      # Import formatting
+    - misspell       # Spelling in comments/strings
+    - gocyclo        # Cyclomatic complexity
+    - bodyclose      # HTTP response body close
+    - errname        # Error naming (Err prefix, Error suffix)
+    - errorlint      # Correct errors.Is/As usage
+    - wrapcheck      # External errors wrapped
+```
+
+## Common Anti-Patterns
+
+| Anti-Pattern | Correct Alternative |
+|---|---|
+| `err == ErrNotFound` with wrapped errors | `errors.Is(err, ErrNotFound)` |
+| `fmt.Errorf("ctx: %v", err)` when unwrap needed | `fmt.Errorf("ctx: %w", err)` |
+| Log and continue on error inside function | Return error, let caller decide |
+| `math/rand` for tokens/nonces | `crypto/rand` |
+| MD5/SHA-1 for security hashes | SHA-256+ for integrity, bcrypt/Argon2id for passwords |
+| `utils`, `helpers`, `common` packages | Descriptive domain-specific names |
+| Bare `go test ./...` in CI | `go test -race ./...` |
+| Storing `context.Context` in struct | Pass as first function parameter |
+| Giant interfaces (5+ methods) | Small interfaces (1-2 methods) |
+| `panic` for normal error flow | Return error values |
+
+## Security Review Points
+
+### SSRF Prevention
+- URL scheme: only `http`/`https`
+- Resolved IP: block private ranges (127.x, 10.x, 172.16-31.x, 192.168.x, 169.254.x)
+- Domain allowlist over blocklist
+- No automatic redirect following without re-validation
+
+### Crypto
+- Passwords: `bcrypt` cost >= 12 or Argon2id
+- Random: `crypto/rand` only
+- TLS: minimum 1.2, prefer 1.3, AEAD cipher suites only
+- Never hardcode secrets
+
+### Input Validation
+- Parameterized SQL queries only
+- File paths: reject `..` and URL-encoded variants
+- HTML: `html/template` not `text/template`
+
+## Module Hygiene
+
+- `go.mod` version matches actual minimum Go requirement
+- `go.sum` committed alongside `go.mod`
+- `go mod tidy` produces no diff
+- No `replace` directives in published libraries
+- `govulncheck ./...` passes

--- a/plugins/go-dev/skills/testing-go/SKILL.md
+++ b/plugins/go-dev/skills/testing-go/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: testing-go
+description: Writes Go tests following TDD with table-driven tests, subtests, fuzz testing, and benchmarks. Use when writing unit tests, integration tests, or benchmarks.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, Edit, Write, Bash
+  argument-hint: [test-scope or package-name]
+  stability: stable
+  content-hash: sha256:placeholder
+  last-verified-cc-version: 2.1.0
+---
+
+# Go Testing
+
+**Target**: $ARGUMENTS
+
+Writes **focused, behavior-driven tests** following Go testing conventions.
+
+## Quick Reference
+
+**Full documentation**: `references/go-testing-patterns.md`
+
+## Quick Decision
+
+**TDD (default)**: Table-driven tests with `t.Run()` subtests.
+**Fuzz**: Use `testing.F` for parser/validator inputs.
+**Benchmark**: Use `testing.B` for performance-critical paths.
+**Integration**: Guard with `//go:build integration` tag.
+
+## TDD Essentials
+
+**Cycle**: RED (failing test) → GREEN (minimal pass) → REFACTOR (clean up)
+
+**Structure**: Table-driven with Arrange-Act-Assert
+
+```go
+func TestDivide(t *testing.T) {
+    tests := []struct {
+        name    string
+        a, b    int
+        want    int
+        wantErr error
+    }{
+        {"positive division", 10, 2, 5, nil},
+        {"divide by zero", 10, 0, 0, ErrDivideByZero},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := Divide(tt.a, tt.b)
+            if !errors.Is(err, tt.wantErr) {
+                t.Errorf("Divide(%d, %d) error = %v; want %v", tt.a, tt.b, err, tt.wantErr)
+            }
+            if got != tt.want {
+                t.Errorf("Divide(%d, %d) = %d; want %d", tt.a, tt.b, got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## What to Test
+
+**High-Value**: Business logic, error paths, integration points, edge cases
+
+**Avoid**: Library behavior, trivial assertions, implementation details
+
+## Naming Convention
+
+**Format**: `Test{Function}_{scenario}` or descriptive table entry names
+
+```go
+func TestValidateUser_EmptyEmailReturnsError(t *testing.T) { ... }
+```
+
+## Execution
+
+```bash
+go test ./...                          # All tests
+go test -race ./...                    # With race detector
+go test -run TestUser ./...            # Filter by name
+go test -tags=integration ./...        # Integration tests
+go test -fuzz=FuzzParse -fuzztime=30s  # Fuzz testing
+go test -bench=. -benchmem ./...       # Benchmarks
+go test -coverprofile=c.out ./...      # Coverage
+```
+
+## Quality Gates
+
+- [ ] All tests pass (`go test -race ./...`)
+- [ ] TDD Red-Green-Refactor followed
+- [ ] Table-driven structure with `t.Run()` subtests
+- [ ] Descriptive test names explaining the scenario
+- [ ] `errors.Is`/`errors.As` for error comparison
+- [ ] `t.Helper()` in shared test helpers
+- [ ] `t.TempDir()` for filesystem isolation
+- [ ] No shared mutable state with `t.Parallel()`

--- a/plugins/go-dev/skills/testing-go/references/go-testing-patterns.md
+++ b/plugins/go-dev/skills/testing-go/references/go-testing-patterns.md
@@ -1,0 +1,132 @@
+# Go Testing Patterns Reference
+
+## Table-Driven Tests
+
+The canonical Go testing pattern. Each case is a struct; `t.Run()` creates
+independent subtests that can be filtered with `-run`.
+
+```go
+tests := []struct {
+    name    string
+    input   string
+    want    Result
+    wantErr error
+}{
+    {"valid input", "hello", Result{OK: true}, nil},
+    {"empty input", "", Result{}, ErrEmpty},
+}
+
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        got, err := Process(tt.input)
+        if !errors.Is(err, tt.wantErr) {
+            t.Fatalf("error = %v, want %v", err, tt.wantErr)
+        }
+        if got != tt.want {
+            t.Errorf("got %v, want %v", got, tt.want)
+        }
+    })
+}
+```
+
+## Parallel Tests
+
+```go
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        t.Parallel() // Only when tests have no shared mutable state
+        // ...
+    })
+}
+```
+
+Note: Go 1.22+ fixes loop variable capture. For pre-1.22: `tt := tt` before
+`t.Parallel()`.
+
+## Test Helpers
+
+```go
+func assertNoError(t *testing.T, err error) {
+    t.Helper() // Error points to caller, not this function
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+}
+```
+
+## Fuzz Testing (Go 1.18+)
+
+```go
+func FuzzParseInput(f *testing.F) {
+    f.Add("valid-seed")
+    f.Fuzz(func(t *testing.T, s string) {
+        _, _ = ParseInput(s) // Must not panic
+    })
+}
+```
+
+Run: `go test -fuzz=FuzzParseInput -fuzztime=30s`
+
+## Benchmarks
+
+```go
+func BenchmarkProcess(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        Process(input)
+    }
+}
+```
+
+Run: `go test -bench=. -benchmem ./...`
+
+## Integration Tests (Build Tags)
+
+```go
+//go:build integration
+
+package mypackage_test
+```
+
+Run: `go test -tags=integration ./...`
+
+Keeps `go test ./...` fast for daily development.
+
+## HTTP Testing
+
+```go
+func TestHandler(t *testing.T) {
+    srv := httptest.NewServer(myHandler())
+    defer srv.Close()
+
+    resp, err := http.Get(srv.URL + "/api/v1/resource")
+    // ...
+}
+```
+
+No external mocking library needed for HTTP — use `net/http/httptest`.
+
+## Mocking Strategy
+
+- Accept interfaces, return structs
+- Use `net/http/httptest` for HTTP
+- Use `t.TempDir()` for filesystem
+- Use `testcontainers-go` for real databases in integration tests
+- Generate mocks with `gomock` or `testify/mock` when needed
+
+## Coverage
+
+```bash
+go test -coverprofile=coverage.out ./...
+go tool cover -func=coverage.out      # Summary
+go tool cover -html=coverage.out      # Visual
+```
+
+Target 70-80% on critical paths. Coverage is a signal, not a target.
+
+## Race Detector
+
+```bash
+go test -race ./...
+```
+
+Non-negotiable for concurrent code. Always enabled in CI.


### PR DESCRIPTION
## Summary

- New `go-dev` plugin mirroring the `python-dev` pattern
- 3 skills: `implementing-go`, `testing-go`, `reviewing-go` with reference docs
- Scaffold adapter for Ralph loop (`go test`, `golangci-lint`, `go vet`, `gocyclo`)
- 4 CI workflow templates: `go-test`, `golangci-lint`, `govulncheck`, `dependabot`
- Testing rule path-filtered to `**/*_test.go`
- SessionStart hook gated on `.scaffold == "go"`
- Bash permissions for Go toolchain
- Marketplace version bumped to 3.1.0

## Test plan

- [ ] `jq .` validates all JSON files
- [ ] `bash -n` passes on all shell scripts
- [ ] Skills reference files exist at declared relative paths
- [ ] Plugin structure matches python-dev/embedded-dev pattern

Generated with Claude <noreply@anthropic.com>