### PR TITLE
feat(rust-dev): add Rust language plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code utility plugins for development, architecture, auditing, documentation, market research, and CC meta-skills",
-    "version": "3.1.0"
+    "version": "3.2.0"
   },
   "plugins": [
     {
@@ -90,6 +90,12 @@
       "name": "market-research",
       "source": "./plugins/market-research",
       "description": "GTM market research pipeline with teams mode parallel dispatch and configurable 2x2 strategy matrix",
+      "version": "1.0.0"
+    },
+    {
+      "name": "rust-dev",
+      "source": "./plugins/rust-dev",
+      "description": "Rust implementation, testing, code review skills, and scaffold adapter for Ralph loop",
       "version": "1.0.0"
     }
   ]

--- a/plugins/rust-dev/.claude-plugin/plugin.json
+++ b/plugins/rust-dev/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "rust-dev",
+  "version": "1.0.0",
+  "description": "Rust implementation, testing, and code review skills, deploys cargo permissions via SessionStart hook",
+  "author": { "name": "Claude Code Utils Contributors" },
+  "keywords": ["rust", "cargo", "clippy", "implementation", "testing", "review"]
+}

--- a/plugins/rust-dev/README.md
+++ b/plugins/rust-dev/README.md
@@ -1,0 +1,51 @@
+# rust-dev
+
+Rust implementation, testing, and code review skills with scaffold adapter for Ralph loop.
+
+## Skills
+
+| Skill | Trigger |
+|-------|---------|
+| `implementing-rust` | Writing Rust code, creating crates, implementing features |
+| `testing-rust` | Writing tests, TDD, property tests, benchmarks |
+| `reviewing-rust` | Code review for safety, correctness, idiomatic style |
+
+## Scaffold Adapter
+
+| Function | Command |
+|----------|---------|
+| `_scaffold_test` | `cargo nextest run` (fallback: `cargo test`) |
+| `_scaffold_lint` | `cargo fmt --check && cargo clippy -- -D warnings` |
+| `_scaffold_typecheck` | `cargo check --all-targets` |
+| `_scaffold_complexity` | `cargo clippy -- -W clippy::cognitive_complexity` |
+| `_scaffold_coverage` | `cargo llvm-cov --summary-only` (fallback: `cargo test`) |
+| `_scaffold_validate` | `make validate` or lint+typecheck+test sequence |
+| `_scaffold_signatures` | Extract `pub fn/struct/enum/trait/impl` signatures |
+| `_scaffold_file_pattern` | `*.rs` |
+
+## CI Workflow Templates
+
+Deployed to `.github/workflows/` when `.scaffold == "rust"`:
+
+- `cargo-test.yaml` — format check + clippy + tests
+- `cargo-audit.yaml` — RustSec vulnerability scanning
+- `dependabot.yaml` — automated Cargo + GHA dependency updates
+
+## Settings
+
+Grants Bash permissions for: `cargo build`, `cargo test`, `cargo check`,
+`cargo clippy`, `cargo fmt`, `cargo audit`, `cargo deny`, `cargo doc`,
+`cargo nextest`, `rustup`.
+
+## Authoritative References
+
+All skills reference first-party Rust documentation:
+
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/checklist.html) (Rust Library Team)
+- [Clippy Lint Index](https://rust-lang.github.io/rust-clippy/stable/index.html) (Rust Clippy Team)
+- [Rust Reference: Unsafety](https://doc.rust-lang.org/reference/unsafety.html) (Rust Language Team)
+- [Cargo Manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) (Cargo Team)
+- [Rustdoc Conventions](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html) (Rust Docs Team)
+- [RustSec Advisories](https://rustsec.org/) (Rust Secure Code WG)
+- [ANSSI Security Guide](https://anssi-fr.github.io/rust-guide/) (French National Cybersecurity Agency)
+- [Rust Performance Book](https://nnethercote.github.io/perf-book/) (N. Nethercote, Rust compiler team)

--- a/plugins/rust-dev/hooks/hooks.json
+++ b/plugins/rust-dev/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/setup-rust-dev.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/rust-dev/hooks/scripts/setup-rust-dev.sh
+++ b/plugins/rust-dev/hooks/scripts/setup-rust-dev.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+PLUGIN_DIR="$CLAUDE_PLUGIN_ROOT"
+SCAFFOLD_DIR="$PLUGIN_DIR/scaffold"
+DEPLOYED=()
+
+# Deploy cargo permissions to .claude/settings.local.json (copy-if-not-exists)
+if command -v cargo >/dev/null 2>&1; then
+  TARGET=".claude/settings.local.json"
+  if [ ! -f "$TARGET" ]; then
+    mkdir -p .claude
+    cp "$PLUGIN_DIR/settings/settings.local.json" "$TARGET"
+    DEPLOYED+=("settings: settings.local.json (cargo permissions)")
+  fi
+fi
+
+# Deploy scaffold adapter (copy-if-not-exists)
+if [ -f ".scaffold" ] && [ "$(cat .scaffold 2>/dev/null)" = "rust" ]; then
+  # Adapter script for Ralph Loop
+  mkdir -p .scaffolds
+  if [ ! -f ".scaffolds/rust.sh" ]; then
+    cp "$SCAFFOLD_DIR/adapter.sh" ".scaffolds/rust.sh"
+    DEPLOYED+=("scaffold: .scaffolds/rust.sh (Ralph adapter)")
+  fi
+
+  # Testing rule (copy-if-not-exists)
+  if [ -d "$SCAFFOLD_DIR/rules" ]; then
+    mkdir -p .claude/rules
+    for rule_file in "$SCAFFOLD_DIR/rules/"*.md; do
+      [ -f "$rule_file" ] || continue
+      local_name=".claude/rules/$(basename "$rule_file")"
+      if [ ! -f "$local_name" ]; then
+        cp "$rule_file" "$local_name"
+        DEPLOYED+=("rule: $(basename "$rule_file")")
+      fi
+    done
+  fi
+
+  # CI workflows (copy-if-not-exists)
+  if [ -d "$SCAFFOLD_DIR/workflows" ]; then
+    mkdir -p .github/workflows
+    for wf_file in "$SCAFFOLD_DIR/workflows/"*.yaml; do
+      [ -f "$wf_file" ] || continue
+      local_name=".github/workflows/$(basename "$wf_file")"
+      if [ ! -f "$local_name" ]; then
+        cp "$wf_file" "$local_name"
+        DEPLOYED+=("workflow: $(basename "$wf_file")")
+      fi
+    done
+  fi
+
+  # Dependabot config (copy-if-not-exists)
+  if [ -f "$SCAFFOLD_DIR/workflows/dependabot.yaml" ] && [ ! -f ".github/dependabot.yaml" ]; then
+    cp "$SCAFFOLD_DIR/workflows/dependabot.yaml" ".github/dependabot.yaml"
+    DEPLOYED+=("config: dependabot.yaml")
+  fi
+fi
+
+# Report
+if [ ${#DEPLOYED[@]} -gt 0 ]; then
+  echo "# Rust Dev Setup"
+  echo ""
+  echo "Deployed ${#DEPLOYED[@]} file(s):"
+  for item in "${DEPLOYED[@]}"; do
+    echo "  - $item"
+  done
+fi

--- a/plugins/rust-dev/scaffold/adapter.sh
+++ b/plugins/rust-dev/scaffold/adapter.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# Rust scaffold adapter for Ralph Loop
+# Deployed to .scaffolds/rust.sh by rust-dev plugin hook.
+# Provides Rust-specific implementations of adapter_* interface.
+#
+# Tools: cargo, rustfmt, clippy, cargo-nextest (optional), cargo-llvm-cov (optional)
+#
+
+# Run tests. Prefers cargo-nextest for speed; falls back to cargo test.
+_scaffold_test() {
+    if command -v cargo-nextest >/dev/null 2>&1; then
+        cargo nextest run "$@"
+    else
+        cargo test "$@"
+    fi
+}
+
+# Format check + lint with clippy (deny warnings).
+_scaffold_lint() {
+    cargo fmt --check
+    cargo clippy --all-targets -- -D warnings
+}
+
+# Static type checking via cargo check (Rust enforces types at compile time).
+_scaffold_typecheck() {
+    cargo check --all-targets
+}
+
+# Cognitive complexity analysis via clippy restriction lint.
+_scaffold_complexity() {
+    cargo clippy --all-targets -- -W clippy::cognitive_complexity
+}
+
+# Run tests with coverage. Prefers cargo-llvm-cov; falls back to cargo test.
+_scaffold_coverage() {
+    if command -v cargo-llvm-cov >/dev/null 2>&1; then
+        cargo llvm-cov --summary-only
+    else
+        cargo test 2>&1 | tail -5
+    fi
+}
+
+# Full validation sequence.
+_scaffold_validate() {
+    if [ -f Makefile ] && make -n validate >/dev/null 2>&1; then
+        make validate
+    else
+        _scaffold_lint && _scaffold_typecheck && _scaffold_test
+    fi
+}
+
+# Extract pub function/struct/enum/trait/impl signatures from a Rust file.
+_scaffold_signatures() {
+    local filepath="$1"
+    grep -nE "^(pub (async )?fn |pub struct |pub enum |pub trait |impl )" "$filepath" 2>/dev/null || true
+}
+
+# Glob pattern for Rust source files.
+_scaffold_file_pattern() {
+    echo "*.rs"
+}
+
+# Set up Rust environment.
+_scaffold_env_setup() {
+    export RUST_BACKTRACE=1
+}
+
+# Generate Rust-specific application docs (minimal main.rs example).
+_scaffold_app_docs() {
+    local src_dir="$1"
+    local app_name
+    app_name=$(basename "$src_dir")
+    local example_path="$src_dir/main.rs"
+
+    [ -f "$example_path" ] && return 0
+
+    cat > "$example_path" <<RSEOF
+//! Minimal viable example demonstrating how to use this application.
+
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    // TODO: Add your example usage here
+    println!("Example: Running $app_name");
+    Ok(())
+}
+RSEOF
+}

--- a/plugins/rust-dev/scaffold/rules/testing.md
+++ b/plugins/rust-dev/scaffold/rules/testing.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "tests/**/*.rs"
+  - "src/**/*_test.rs"
+  - "benches/**/*.rs"
+---
+
+# Testing Rules (Rust)
+
+- Use in-module `#[cfg(test)]` for unit tests, `tests/` for integration tests
+- Use `#[should_panic(expected = "...")]` for panic tests, not bare `#[should_panic]`
+- Use `tempfile` crate for filesystem isolation, never write to project dirs
+- Prefer `proptest` for property-based tests on parsing/validation/serialization logic
+- Use `criterion` for benchmarks in `benches/`, never time operations in `#[test]` functions
+- Use `assert_eq!(actual, expected)` not `assert!(actual == expected)` for better error messages
+- Test names: `test_{module}_{behavior}` (e.g., `test_parser_rejects_empty_input`)
+- Reference issues in regression tests: `// Reproduces #123: ...`

--- a/plugins/rust-dev/scaffold/workflows/cargo-audit.yaml
+++ b/plugins/rust-dev/scaffold/workflows/cargo-audit.yaml
@@ -1,0 +1,16 @@
+name: cargo-audit
+permissions:
+  contents: read
+on:
+  push:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/plugins/rust-dev/scaffold/workflows/cargo-test.yaml
+++ b/plugins/rust-dev/scaffold/workflows/cargo-test.yaml
@@ -1,0 +1,25 @@
+name: cargo-test
+permissions:
+  contents: read
+on:
+  push:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Format check
+        run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Tests
+        run: cargo test --all-features

--- a/plugins/rust-dev/scaffold/workflows/dependabot.yaml
+++ b/plugins/rust-dev/scaffold/workflows/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/plugins/rust-dev/settings/settings.local.json
+++ b/plugins/rust-dev/settings/settings.local.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo build:*)",
+      "Bash(cargo test:*)",
+      "Bash(cargo check:*)",
+      "Bash(cargo clippy:*)",
+      "Bash(cargo fmt:*)",
+      "Bash(cargo audit:*)",
+      "Bash(cargo deny:*)",
+      "Bash(cargo doc:*)",
+      "Bash(cargo nextest:*)",
+      "Bash(rustup:*)"
+    ]
+  }
+}

--- a/plugins/rust-dev/skills/implementing-rust/SKILL.md
+++ b/plugins/rust-dev/skills/implementing-rust/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: implementing-rust
+description: Implements idiomatic Rust code matching architect specifications. Use when writing Rust code, creating crates, or when the user asks to implement features in Rust.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, Edit, Write, Bash, WebSearch, WebFetch
+  argument-hint: [feature-name]
+  stability: stable
+---
+
+# Rust Implementation
+
+**Target**: $ARGUMENTS
+
+Creates **focused, idiomatic** Rust implementations following architect
+specifications exactly. No over-engineering.
+
+## Rust Standards
+
+See `references/rust-best-practices.md` for comprehensive Rust guidelines.
+
+## Workflow
+
+1. **Read architect specifications** from provided documents
+2. **Validate scope** — Simple (single module) vs Complex (workspace/multi-crate)
+3. **Study existing patterns** in `src/` structure
+4. **Implement minimal solution** matching stated functionality
+5. **Create focused tests** matching task complexity
+6. **Run validation** and fix all issues
+
+## Implementation Strategy
+
+**Simple Tasks**: Single module, `Result<T, E>` returns, in-module `#[cfg(test)]`
+unit tests, `anyhow` for error propagation
+
+**Complex Tasks**: Multi-module with `thiserror` error types, trait-based design,
+`proptest` for edge cases, integration tests in `tests/`
+
+**Always**: Use existing project patterns, match `Cargo.toml` lint config
+
+## Output Standards
+
+**Simple Tasks**: Focused functions with doc comments and unit tests
+**Complex Tasks**: Complete modules with `# Errors`/`# Panics` docs and full test coverage
+**All outputs**: Idiomatic, no `.unwrap()` in non-test code, `// SAFETY:` on any `unsafe`
+
+## Quality Checks
+
+Before completing any task:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --all-features
+```
+
+All formatting, lints, and tests must pass.

--- a/plugins/rust-dev/skills/implementing-rust/references/rust-best-practices.md
+++ b/plugins/rust-dev/skills/implementing-rust/references/rust-best-practices.md
@@ -1,0 +1,325 @@
+---
+title: Rust Best Practices Reference
+version: 1.0
+applies-to: Agents and humans
+purpose: Security-first Rust coding standards with type safety, error handling, and toolchain patterns
+sources:
+  - https://rust-lang.github.io/api-guidelines/checklist.html
+  - https://rust-lang.github.io/rust-clippy/stable/index.html
+  - https://doc.rust-lang.org/reference/unsafety.html
+  - https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html
+  - https://doc.rust-lang.org/cargo/reference/manifest.html
+  - https://rustsec.org/
+  - https://anssi-fr.github.io/rust-guide/
+  - https://nnethercote.github.io/perf-book/
+---
+
+## Error Handling (Non-Negotiable)
+
+### Decision Tree
+
+| Context | Crate | Pattern |
+|---------|-------|---------|
+| Library crate (public API) | `thiserror` | Derive `Error` on enum, callers match variants |
+| Binary crate / `main()` | `anyhow` | `Result<()>` + `.context()` chaining |
+| Tests | — | `.unwrap()` / `.expect("test context")` acceptable |
+| Never in library APIs | — | `unwrap()`, `expect()`, `panic!()` |
+
+**Library error type** ([thiserror](https://docs.rs/thiserror)):
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("parse error at position {position}: {message}")]
+    Parse { position: usize, message: String },
+
+    #[error("invalid configuration: {0}")]
+    Config(String),
+}
+```
+
+**Application error propagation** ([anyhow](https://docs.rs/anyhow)):
+
+```rust
+use anyhow::{Context, Result};
+
+fn read_config(path: &Path) -> Result<Config> {
+    let contents = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read config from {path:?}"))?;
+    serde_json::from_str(&contents)
+        .context("Config file is not valid JSON")
+}
+```
+
+**Rule**: Never mix `thiserror` and `anyhow` in the same crate's public API. `thiserror` for what callers see, `anyhow` for internal propagation in binaries.
+
+### Panic Policy
+
+- `panic!()` only for programmer errors (violated invariants), never for user input
+- Destructors (`Drop`) must never panic — log and absorb errors
+- Prefer `?` operator over `.unwrap()` / `.expect()` in all non-test code
+
+Ref: [Rust API Guidelines — C-VALIDATE](https://rust-lang.github.io/api-guidelines/checklist.html)
+
+## Unsafe Code Policy
+
+Ref: [Rust Reference — Unsafety](https://doc.rust-lang.org/reference/unsafety.html), [ANSSI Secure Coding Guide](https://anssi-fr.github.io/rust-guide/)
+
+### The 8 Unsafe Operations (Rust 2024)
+
+1. Dereference raw pointers (`*const T` / `*mut T`)
+2. Read/write mutable or unsafe static variables
+3. Access fields of a `union`
+4. Call `unsafe fn` functions
+5. Call safe functions marked `#[target_feature]` without matching attributes
+6. Implement `unsafe trait`
+7. Declare `unsafe extern { ... }` blocks (Rust 2024 edition requires `unsafe` keyword)
+8. Apply unsafe attributes
+
+### Rules
+
+- **Every `unsafe` block requires a `// SAFETY:` comment** explaining the invariants
+- Minimize scope: smallest possible `unsafe` block, wrap in a safe abstraction immediately
+- Use `#![forbid(unsafe_code)]` in library crates; `#![deny(unsafe_code)]` in binaries with audited exceptions
+- FFI: use `CStr`/`CString`, never raw pointer arithmetic without bounds proof
+- Run `cargo-geiger` to quantify unsafe surface in dependency tree
+
+```rust
+// SAFETY: `ptr` is guaranteed non-null and aligned by the allocator contract
+// in `Buffer::new()`. The lifetime is bounded by `&self`.
+let value = unsafe { &*self.ptr };
+```
+
+## Type Safety
+
+Ref: [Rust API Guidelines — Type Safety](https://rust-lang.github.io/api-guidelines/checklist.html)
+
+- **Newtypes for static distinctions**: `struct Meters(f64)` vs `struct Seconds(f64)` — prevents argument confusion
+- **Prefer enum/newtype arguments over `bool`**: `fn connect(mode: TlsMode)` not `fn connect(use_tls: bool)`
+- **Builder pattern** for structs with 4+ fields or complex validation
+- **`as` casts are dangerous**: use `.try_into()` or `TryFrom` for numeric conversions to catch truncation/sign loss
+- Use checked arithmetic for user-controlled values: `.checked_add()`, `.saturating_add()`
+- Eagerly implement `Clone, Debug, PartialEq, Eq, Hash` on public types ([C-COMMON-TRAITS](https://rust-lang.github.io/api-guidelines/checklist.html))
+
+## Clippy Lint Configuration
+
+Ref: [Clippy Lint Index](https://rust-lang.github.io/rust-clippy/stable/index.html)
+
+Configure in `Cargo.toml` (modern, workspace-aware — replaces `#![deny(...)]` in source):
+
+```toml
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+# High-value restriction lints
+unwrap_used = "warn"
+expect_used = "warn"
+panic = "warn"
+dbg_macro = "warn"
+todo = "warn"
+# High-value pedantic lints (already included in pedantic group)
+missing_errors_doc = "deny"
+missing_panics_doc = "deny"
+cast_possible_truncation = "warn"
+# Commonly suppressed pedantic lints (with reason)
+module_name_repetitions = "allow"  # unavoidable in idiomatic module layout
+must_use_candidate = "allow"       # noisy for non-critical functions
+```
+
+**Never** put `#![deny(warnings)]` in source code — breaks downstream builds when new warnings are added. Use `RUSTFLAGS="-D warnings"` in CI only.
+
+### Lint Groups
+
+| Group | Level | Purpose |
+|-------|-------|---------|
+| `correctness` | deny (default) | Actual bugs — always fix |
+| `suspicious` | warn (default) | Patterns that seem unintended |
+| `style` | warn (default) | Idiomatic Rust style |
+| `pedantic` | allow (opt-in) | Stricter guidelines — enable project-wide |
+| `restriction` | allow (opt-in) | Enable per-lint only, not as group |
+
+## Cargo.toml Best Practices
+
+Ref: [Cargo Manifest Format](https://doc.rust-lang.org/cargo/reference/manifest.html)
+
+```toml
+[package]
+name = "my-crate"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.75"              # MSRV — always set explicitly
+description = "One-line summary"
+license = "MIT OR Apache-2.0"      # Dual-license is Rust ecosystem convention
+repository = "https://github.com/..."
+keywords = ["max", "five", "words"]
+categories = ["development-tools"]
+
+[features]
+default = []                       # Keep defaults minimal
+serde = ["dep:serde"]              # Gate optional deps behind features
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+strip = true
+```
+
+### Workspace Layout
+
+```toml
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+```
+
+### Cargo.lock Policy
+
+- **Commit** `Cargo.lock` for binaries and applications
+- **Gitignore** `Cargo.lock` for library crates
+
+## Documentation (rustdoc)
+
+Ref: [Rustdoc: How to Write Documentation](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html)
+
+Every `pub` item needs a doc comment. Required sections:
+
+```rust
+/// Brief one-line description (shown in module overview).
+///
+/// Longer description with context and edge cases.
+///
+/// # Errors
+///
+/// Returns [`AppError::Parse`] if `input` contains invalid UTF-8.
+///
+/// # Panics
+///
+/// Panics if `limit` is zero.
+///
+/// # Safety (unsafe fn only)
+///
+/// Caller must ensure `ptr` is non-null and points to valid memory.
+///
+/// # Examples
+///
+/// ```rust
+/// use my_crate::parse;
+/// let result = parse("hello")?;
+/// assert_eq!(result.len(), 5);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn parse(input: &str) -> Result<Ast, AppError> { ... }
+```
+
+- Use `?` in examples, not `.unwrap()` — per [API Guidelines](https://rust-lang.github.io/api-guidelines/checklist.html)
+- Hide boilerplate with `# ` prefix lines (visible in source, hidden in rendered docs)
+- Module-level `//!` docs in `lib.rs` with overview + quickstart example
+- Type signatures are auto-linked — do not duplicate in prose
+
+## Security
+
+Ref: [RustSec Advisory Database](https://rustsec.org/), [ANSSI Rust Guide](https://anssi-fr.github.io/rust-guide/)
+
+### Supply Chain
+
+- `cargo audit` — scan `Cargo.lock` against RustSec advisories (run in CI)
+- `cargo deny` — enforce license policy + ban specific crates + advisory scanning
+
+```toml
+# deny.toml
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+
+[licenses]
+allow = ["MIT", "Apache-2.0", "Apache-2.0 WITH LLVM-exception"]
+
+[bans]
+multiple-versions = "warn"
+```
+
+### Secrets
+
+- Environment variables only, never hardcoded in source
+- Use `secrecy::Secret<String>` to prevent accidental logging of sensitive values
+
+### Deserialization
+
+- Validate untrusted data with `serde` + Rust type constraints
+- Avoid `#[serde(flatten)]` on untrusted input (can bypass validation)
+- Set size limits on deserialized collections
+
+### Integer Safety
+
+- Debug builds trap overflow (panic), release builds wrap silently
+- Use `.checked_add()` / `.saturating_add()` for user-controlled values
+- Enable `clippy::arithmetic_side_effects` for security-critical code
+
+## Ownership & Lifetimes
+
+### Parameter Guidelines
+
+| Situation | Use |
+|-----------|-----|
+| Read-only, no ownership needed | `&str`, `&[T]`, `&Path` |
+| Need to store/return owned data | `String`, `Vec<T>`, `PathBuf` |
+| Sometimes owned, sometimes borrowed | `Cow<'_, str>` (only when genuinely needed) |
+| Accept anything string-like | `impl AsRef<str>` or `&str` |
+
+- Prefer `&str` over `String` for function parameters that don't need ownership
+- Name lifetimes explicitly when two or more references appear in the same signature
+- Avoid `.clone()` to fix borrow errors — restructure ownership instead
+
+## Naming Conventions
+
+Ref: [Rust API Guidelines — Naming](https://rust-lang.github.io/api-guidelines/checklist.html)
+
+| Item | Convention | Example |
+|------|-----------|---------|
+| Types, traits | `UpperCamelCase` | `HttpClient`, `IntoIterator` |
+| Functions, methods, modules | `snake_case` | `read_config`, `into_inner` |
+| Constants, statics | `SCREAMING_SNAKE_CASE` | `MAX_RETRIES` |
+| Conversions | `as_`/`to_`/`into_` | `as_bytes()` (cheap), `to_string()` (alloc), `into_inner()` (consuming) |
+| Iterators | `iter()`/`iter_mut()`/`into_iter()` | On collections |
+| Getters | `fn field(&self) -> T` | No `get_` prefix (idiomatic Rust) |
+
+## Common Anti-Patterns
+
+| Anti-Pattern | Impact | Fix |
+|-------------|--------|-----|
+| `.unwrap()` in library code | Panics propagate to callers | Return `Result<T, E>` |
+| `anyhow` in lib crate public API | Opaque errors for callers | Use `thiserror` |
+| `clone()` to fix borrow errors | Hidden performance cost | Restructure ownership |
+| `#![deny(warnings)]` in lib.rs | Breaks downstream on nightly | Use `[lints]` in Cargo.toml |
+| `lazy_static!` for new code | Outdated | Use `std::sync::OnceLock` (stable since 1.70) |
+| `as` for numeric casts | Silent truncation/sign loss | Use `.try_into()` |
+| Missing `// SAFETY:` on unsafe | Code review rejection | Always document invariants |
+| `String` params that should be `&str` | Unnecessary allocation | Accept `&str` or `impl AsRef<str>` |
+| Global mutable state (`static mut`) | Data races, UB | Use `Mutex<T>` or `OnceLock<T>` |
+| Panic in `Drop` | Double panic → abort | Log and absorb errors |
+| `Box<Vec<T>>` | Double indirection | Use `Vec<T>` directly |
+
+## Performance
+
+Ref: [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+
+- Profile before optimizing: `cargo flamegraph`, `criterion` benchmarks
+- `String::with_capacity(n)` for known-size string building
+- `cargo build --timings` for compile-time analysis
+- Avoid monomorphization bloat: extract non-generic logic from generic functions
+- `cargo llvm-lines` to find functions generating excessive LLVM IR

--- a/plugins/rust-dev/skills/reviewing-rust/SKILL.md
+++ b/plugins/rust-dev/skills/reviewing-rust/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: reviewing-rust
+description: Provides focused Rust code reviews for safety, correctness, and idiomatic style. Use when reviewing Rust code quality, security, or pull requests.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, Bash
+  argument-hint: [file-or-pr-scope]
+  stability: stable
+---
+
+# Rust Code Review
+
+**Target**: $ARGUMENTS
+
+Provides **concise, focused** Rust code reviews checking safety, correctness,
+and idiomatic style.
+
+## Rust Review Standards
+
+See `references/rust-review-checklist.md` for the full checklist.
+
+## Workflow
+
+1. **Identify changed files** — `git diff --name-only main...HEAD -- '*.rs' 'Cargo.toml'`
+2. **Read changed code** and understand the intent
+3. **Apply checklist** from `references/rust-review-checklist.md`
+4. **Report findings** grouped by severity (critical → suggestion)
+5. **Verify fixes** if changes are made
+
+## Review Scope
+
+**Always check**: Safety (`unsafe`), error handling, clippy compliance, documentation
+
+**Check if relevant**: Performance, dependency changes, API design
+
+## Critical Findings (Must Fix)
+
+- `unsafe` without `// SAFETY:` comment
+- `.unwrap()` / `.expect()` in non-test library code
+- `anyhow` in library public API (should be `thiserror`)
+- Missing `# Errors` / `# Panics` on public functions
+- Hardcoded secrets or credentials
+- Known vulnerable dependencies (`cargo audit`)
+
+## Output Format
+
+```markdown
+## Review: [scope]
+
+### Critical
+- **file:line** — description and fix
+
+### Warnings
+- **file:line** — description and suggestion
+
+### Suggestions
+- **file:line** — improvement opportunity
+```

--- a/plugins/rust-dev/skills/reviewing-rust/references/rust-review-checklist.md
+++ b/plugins/rust-dev/skills/reviewing-rust/references/rust-review-checklist.md
@@ -1,0 +1,85 @@
+---
+title: Rust Code Review Checklist
+version: 1.0
+applies-to: Agents and humans
+purpose: Structured review checklist for Rust code — safety, correctness, idiomatic style
+sources:
+  - https://rust-lang.github.io/api-guidelines/checklist.html
+  - https://rust-lang.github.io/rust-clippy/stable/index.html
+  - https://doc.rust-lang.org/reference/unsafety.html
+  - https://rustsec.org/
+---
+
+## Safety Review
+
+- [ ] Every `unsafe` block has a `// SAFETY:` comment explaining invariants
+- [ ] `unsafe` scope is minimized — wrapped in safe abstraction
+- [ ] No `unsafe` that could be replaced with safe alternatives
+- [ ] FFI calls use `CStr`/`CString`, not raw pointer arithmetic
+- [ ] `#![forbid(unsafe_code)]` or `#![deny(unsafe_code)]` at crate level
+
+## Error Handling
+
+- [ ] Library code uses `thiserror` for error types — no `anyhow` in public API
+- [ ] No `.unwrap()` or `.expect()` in non-test code paths
+- [ ] `?` operator used for propagation, not manual `match` on `Result`
+- [ ] `.context()` / `.with_context()` on fallible operations (binary crates)
+- [ ] Error messages describe what failed and include relevant data
+- [ ] `Drop` implementations never panic
+
+## Clippy & Linting
+
+- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `[lints.clippy]` configured in `Cargo.toml` (not `#![deny(...)]` in source)
+- [ ] `clippy::pedantic` enabled project-wide
+- [ ] `clippy::unwrap_used` and `clippy::expect_used` enabled as warnings
+- [ ] Any `#[allow(clippy::...)]` has a justifying comment
+
+## Documentation (rustdoc)
+
+- [ ] Every `pub` function/struct/enum/trait has a `///` doc comment
+- [ ] `# Errors` section on functions returning `Result`
+- [ ] `# Panics` section on functions that can panic
+- [ ] `# Safety` section on every `unsafe fn`
+- [ ] `# Examples` with runnable doctests using `?` (not `.unwrap()`)
+- [ ] Module-level `//!` docs in `lib.rs`
+
+## Type Safety & API Design
+
+- [ ] Newtypes used for domain distinctions (not bare primitives)
+- [ ] No `bool` parameters — use enums for named options
+- [ ] Numeric conversions use `.try_into()`, not `as` casts
+- [ ] `From`/`Into` for conversions, not ad-hoc methods
+- [ ] `Clone, Debug, PartialEq, Eq` implemented where appropriate
+
+## Security
+
+- [ ] `cargo audit` clean (no known vulnerabilities in dependencies)
+- [ ] No secrets hardcoded in source — environment variables only
+- [ ] Untrusted deserialization uses type constraints (no unrestricted `#[serde(flatten)]`)
+- [ ] Size limits on deserialized collections from external input
+- [ ] Checked arithmetic for user-controlled numeric values
+
+## Dependencies
+
+- [ ] `Cargo.lock` committed (binary crates) or gitignored (library crates)
+- [ ] No unnecessary dependencies — prefer `std` when available
+- [ ] Optional dependencies gated behind `[features]` with `dep:` prefix
+- [ ] `deny.toml` configured for license and advisory enforcement (if applicable)
+
+## Testing
+
+- [ ] New functionality has corresponding tests
+- [ ] Regression tests reference the issue number in a comment
+- [ ] `tempfile` used for filesystem operations (no writes to project dirs)
+- [ ] Property tests (`proptest`) for parsers/serializers/math
+- [ ] Tests compile and pass: `cargo test --all-features`
+
+## Performance (when relevant)
+
+- [ ] No `.clone()` used to work around borrow checker — restructure ownership
+- [ ] `String::with_capacity()` for known-size string building
+- [ ] No `Box<Vec<T>>` or `Box<String>` (double indirection)
+- [ ] Hot paths pre-allocate rather than grow incrementally
+- [ ] `criterion` benchmarks for performance-critical code

--- a/plugins/rust-dev/skills/testing-rust/SKILL.md
+++ b/plugins/rust-dev/skills/testing-rust/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: testing-rust
+description: Writes tests following TDD and property-based testing with proptest. Use when writing unit tests, integration tests, benchmarks, or property tests in Rust.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, Edit, Write, Bash
+  argument-hint: [test-scope or component-name]
+  stability: stable
+---
+
+# Rust Testing
+
+**Target**: $ARGUMENTS
+
+Writes **focused, behavior-driven tests** following project testing patterns.
+
+## Quick Reference
+
+**Full documentation**: `references/rust-testing-patterns.md`
+
+## Quick Decision
+
+**Unit tests**: In-module `#[cfg(test)]` for testing internal logic and private functions.
+
+**Integration tests**: `tests/` directory for testing public API from the outside.
+
+**Property tests**: `proptest` for parsers, serializers, math, domain constraints.
+
+**Benchmarks**: `criterion` in `benches/` for performance regression detection.
+
+## TDD Essentials
+
+**Cycle**: RED (failing test) → GREEN (minimal pass) → REFACTOR (clean up)
+
+**Structure**: Arrange-Act-Assert
+
+```rust
+#[test]
+fn order_processor_calculates_total() {
+    // ARRANGE
+    let items = vec![Item::new(10.00, 2), Item::new(5.00, 1)];
+    let processor = OrderProcessor::new();
+
+    // ACT
+    let total = processor.calculate_total(&items);
+
+    // ASSERT
+    assert_eq!(total, 25.00);
+}
+```
+
+## proptest Priorities
+
+| Priority | Area | Example |
+|----------|------|---------|
+| CRITICAL | Math formulas | Scores always in bounds |
+| CRITICAL | Roundtrips | Encode → decode == identity |
+| HIGH | Input validation | Handles arbitrary strings |
+| HIGH | Serialization | Always valid JSON/TOML |
+
+## What to Test
+
+**High-Value**: Business logic, error paths, edge cases, public API contracts
+
+**Avoid**: Compiler-enforced type safety, trivial getters, third-party crate behavior
+
+## Execution
+
+```bash
+cargo test                     # All tests
+cargo test -- --ignored        # Run ignored (slow) tests
+cargo test parser              # Filter by name
+cargo nextest run              # Faster parallel execution
+cargo bench                    # Benchmarks
+cargo test --doc               # Doctests only
+```
+
+## Quality Gates
+
+- [ ] All tests pass (`cargo test --all-features`)
+- [ ] TDD Red-Green-Refactor followed
+- [ ] Arrange-Act-Assert structure used
+- [ ] `test_{module}_{behavior}` naming convention
+- [ ] Regression tests reference issue number
+- [ ] `tempfile` used for filesystem isolation
+- [ ] No `.unwrap()` in assertions — use `assert!(result.is_ok(), "{result:?}")`

--- a/plugins/rust-dev/skills/testing-rust/references/rust-testing-patterns.md
+++ b/plugins/rust-dev/skills/testing-rust/references/rust-testing-patterns.md
@@ -1,0 +1,237 @@
+---
+title: Rust Testing Patterns Reference
+version: 1.0
+applies-to: Agents and humans
+purpose: Testing patterns for Rust projects — unit, integration, property-based, benchmarks
+sources:
+  - https://doc.rust-lang.org/book/ch11-00-testing.html
+  - https://docs.rs/proptest/latest/proptest/
+  - https://docs.rs/criterion/latest/criterion/
+  - https://nexte.st/
+---
+
+## Test Structure
+
+### In-Module Unit Tests
+
+```rust
+// src/parser.rs
+pub fn parse(input: &str) -> Result<Ast, ParseError> { ... }
+
+fn internal_helper(s: &str) -> bool { ... }
+
+#[cfg(test)]
+mod tests {
+    use super::*;  // Access private functions
+
+    #[test]
+    fn parse_valid_input() {
+        let result = parse("valid").unwrap();
+        assert_eq!(result.node_count(), 1);
+    }
+
+    #[test]
+    fn parse_empty_returns_error() {
+        let err = parse("").unwrap_err();
+        assert!(matches!(err, ParseError::Empty));
+    }
+
+    #[test]
+    #[should_panic(expected = "invariant violated")]
+    fn panics_on_invariant_violation() {
+        dangerous_internal_fn(0);
+    }
+
+    #[test]
+    fn returns_result() -> Result<(), ParseError> {
+        let _ = parse("valid")?;
+        Ok(())
+    }
+}
+```
+
+### Integration Tests
+
+```
+my-crate/
+├── src/lib.rs
+├── tests/
+│   ├── common/
+│   │   └── mod.rs          # Shared fixtures (not run as test file)
+│   ├── integration_test.rs
+│   └── api_test.rs
+└── benches/
+    └── benchmark.rs
+```
+
+```rust
+// tests/integration_test.rs
+use my_crate::parse;
+
+#[test]
+fn end_to_end_parse_and_render() {
+    let ast = parse("input").expect("parse should succeed");
+    let output = ast.render();
+    assert_eq!(output, "expected output");
+}
+```
+
+### Shared Test Fixtures
+
+```rust
+// tests/common/mod.rs
+pub fn sample_config() -> Config {
+    Config { timeout: 30, retries: 3 }
+}
+
+// tests/integration_test.rs
+mod common;
+
+#[test]
+fn test_with_fixture() {
+    let config = common::sample_config();
+    // ...
+}
+```
+
+## Property-Based Testing (proptest)
+
+Use for: parsers, serializers, math operations, any function with domain constraints.
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn parse_roundtrip(s in "[a-z]{1,100}") {
+        let encoded = encode(&s);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded, s);
+    }
+
+    #[test]
+    fn score_always_in_bounds(value in 0.0f64..=100.0) {
+        let score = normalize(value);
+        assert!((0.0..=1.0).contains(&score));
+    }
+}
+```
+
+### Strategy Patterns
+
+| Data Type | Strategy |
+|-----------|----------|
+| Strings | `"[a-z]{1,100}"`, `any::<String>()` |
+| Integers | `0..1000i32`, `any::<u64>()` |
+| Vecs | `prop::collection::vec(0..100i32, 0..50)` |
+| Enums | `prop_oneof![Just(A), Just(B), Just(C)]` |
+| Structs | Derive `Arbitrary` or compose strategies |
+
+## Benchmarking (criterion)
+
+```rust
+// benches/benchmark.rs
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use my_crate::parse;
+
+fn bench_parse(c: &mut Criterion) {
+    let input = "test input data";
+    c.bench_function("parse", |b| {
+        b.iter(|| parse(black_box(input)))
+    });
+}
+
+criterion_group!(benches, bench_parse);
+criterion_main!(benches);
+```
+
+Add to `Cargo.toml`:
+
+```toml
+[[bench]]
+name = "benchmark"
+harness = false
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+```
+
+Run: `cargo bench`
+
+## Filesystem Isolation (tempfile)
+
+```rust
+use tempfile::TempDir;
+
+#[test]
+fn writes_output_file() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("output.txt");
+
+    write_output(&path).unwrap();
+
+    let contents = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(contents, "expected");
+    // dir is automatically cleaned up on drop
+}
+```
+
+## Mocking (mockall)
+
+```rust
+use mockall::automock;
+
+#[automock]
+trait Database {
+    fn get(&self, key: &str) -> Option<String>;
+}
+
+#[test]
+fn service_uses_database() {
+    let mut mock = MockDatabase::new();
+    mock.expect_get()
+        .with(eq("user:1"))
+        .returning(|_| Some("Alice".to_string()));
+
+    let service = Service::new(Box::new(mock));
+    assert_eq!(service.get_user("1"), Some("Alice".to_string()));
+}
+```
+
+## Test Runner: cargo-nextest
+
+[nextest](https://nexte.st/) is faster than `cargo test` for large test suites:
+
+```bash
+cargo install cargo-nextest
+cargo nextest run              # Run all tests
+cargo nextest run -E 'test(parse)'  # Filter by name
+cargo nextest run --retries 2  # Retry flaky tests
+```
+
+**Tradeoff**: nextest does not support doctests — run `cargo test --doc` separately.
+
+## Naming Convention
+
+**Format**: `test_{module}_{behavior}`
+
+```rust
+test_parser_rejects_empty_input()
+test_config_loads_defaults_when_missing()
+test_handler_returns_404_for_unknown_route()
+```
+
+## Regression Tests
+
+Reference the issue in a comment:
+
+```rust
+#[test]
+fn test_json_preserves_special_chars() {
+    // Reproduces #464: package.json with "packages/*" was corrupted
+    // because /* was treated as block comment start
+    let input = r#"{"packages": ["packages/*"]}"#;
+    let output = filter_json(input);
+    assert!(output.contains("packages/*"));
+}
+```


### PR DESCRIPTION
## Summary

- New `rust-dev` plugin with 3 skills: `implementing-rust`, `testing-rust`, `reviewing-rust`
- Scaffold adapter with 8 `_scaffold_*` functions for Ralph loop integration
- CI workflow templates: `cargo-test.yaml`, `cargo-audit.yaml`, `dependabot.yaml`
- SessionStart hook deploys cargo permissions when `cargo` detected on PATH
- All references backed by first-party Rust team URLs (API Guidelines, Clippy, RustSec, ANSSI)
- marketplace.json: added entry, bumped 3.1.0 → 3.2.0

## Key Content

| Skill | Reference | Lines |
|-------|-----------|-------|
| implementing-rust | `rust-best-practices.md` | Error handling, unsafe policy, clippy, Cargo.toml, docs, security, anti-patterns |
| testing-rust | `rust-testing-patterns.md` | cfg(test), proptest, criterion, cargo-nextest, tempfile, mockall |
| reviewing-rust | `rust-review-checklist.md` | Safety, error handling, clippy, rustdoc, security, dependencies |

## Test plan

- [ ] `claude plugin install rust-dev@./plugins/rust-dev` deploys successfully
- [ ] SessionStart hook fires when `cargo` on PATH
- [ ] `.scaffold == "rust"` triggers adapter + rules + workflow deployment
- [ ] `marketplace.json` version matches `plugin.json` version (both 1.0.0)

Generated with Claude <noreply@anthropic.com>