### PR TITLE
docs: add tool results (detached outputs) entry type

### DIFF
--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/cc-entry-types.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/cc-entry-types.md
@@ -122,6 +122,11 @@ format as session `.jsonl` files.
 `~/.claude/projects/<path>/memory/MEMORY.md` — persistent per-project knowledge
 loaded at conversation start.
 
+## Tool Results (Detached Outputs)
+
+`~/.claude/projects/<path>/<session-uuid>/tool-results/<id>.txt` — large tool
+outputs (1KB–138KB) stored externally. Referenced from `assistant` JSONL entries.
+
 ## Path Encoding
 
 Project paths are URL-encoded with dashes:


### PR DESCRIPTION
## Summary
- Document externally stored tool output files (1KB-138KB) referenced from assistant JSONL entries
- Adds new section to cc-entry-types.md reference

## Test plan
- [ ] Verify markdown renders correctly

Generated with Claude <noreply@anthropic.com>