### PR TITLE
chore: add statusline.sh to Makefile sync targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ sync_rules:  ## Sync rules from .claude/rules/ to plugin copies
 	cp .claude/rules/context-management.md plugins/codebase-tools/skills/compacting-context/references/
 
 sync_scripts:  ## Sync scripts from .claude/scripts/ to plugin copies
+	cp .claude/scripts/statusline.sh plugins/workspace-setup/scripts/
+	cp .claude/scripts/statusline.sh plugins/workspace-sandbox/scripts/
 	cp .claude/scripts/read-once/hook.sh plugins/workspace-setup/scripts/read-once/
 	cp .claude/scripts/read-once/compact.sh plugins/workspace-setup/scripts/read-once/
 	cp .claude/scripts/read-once/hook.sh plugins/workspace-sandbox/scripts/read-once/
@@ -55,6 +57,8 @@ check_sync:  ## Verify all copies are in sync with .claude/ SoT
 	@diff -q .claude/rules/core-principles.md plugins/codebase-tools/skills/researching-codebase/references/core-principles.md
 	@diff -q .claude/rules/context-management.md plugins/codebase-tools/skills/researching-codebase/references/context-management.md
 	@diff -q .claude/rules/context-management.md plugins/codebase-tools/skills/compacting-context/references/context-management.md
+	@diff -q .claude/scripts/statusline.sh plugins/workspace-setup/scripts/statusline.sh
+	@diff -q .claude/scripts/statusline.sh plugins/workspace-sandbox/scripts/statusline.sh
 	@diff -q .claude/scripts/read-once/hook.sh plugins/workspace-setup/scripts/read-once/hook.sh
 	@diff -q .claude/scripts/read-once/compact.sh plugins/workspace-setup/scripts/read-once/compact.sh
 	@diff -q .claude/scripts/read-once/hook.sh plugins/workspace-sandbox/scripts/read-once/hook.sh


### PR DESCRIPTION
## Summary
- Add statusline.sh to sync_scripts and check_sync Makefile targets
- SoT at .claude/scripts/statusline.sh, synced to both workspace plugins

🤖 Generated with Claude <noreply@anthropic.com>