### PR TITLE
feat(cc-meta): add MEMORY.md seed template with SessionStart hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,8 +29,8 @@
     {
       "name": "cc-meta",
       "source": "./plugins/cc-meta",
-      "description": "Claude Code meta-skills for cross-project synthesis, context compaction, and session intelligence",
-      "version": "1.3.0"
+      "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
+      "version": "1.4.0"
     },
     {
       "name": "backend-design",

--- a/plugins/cc-meta/.claude-plugin/plugin.json
+++ b/plugins/cc-meta/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-meta",
-  "version": "1.3.0",
-  "description": "Claude Code meta-skills for cross-project synthesis, context compaction, and session intelligence",
+  "version": "1.4.0",
+  "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["meta", "big-picture", "synthesis", "context", "compaction", "sessions", "plans", "reasoning-modes"]
 }

--- a/plugins/cc-meta/examples/memory/MEMORY.md
+++ b/plugins/cc-meta/examples/memory/MEMORY.md
@@ -1,0 +1,31 @@
+# Claude Code Memory
+
+Cross-repo working patterns for AI coding agent workflows.
+
+## Git Conventions
+
+- **Protected mains** — always feature branches + PRs
+- **Squash merge**: `PR <conventional-commit-title> (#NUM)`, branch commits in body
+- **Push**: `git push origin <branch-name>` (never `HEAD` or bare)
+
+## Auth & Credentials
+
+<!-- Project-specific auth patterns (PATs, tokens, SSO) -->
+
+## Sandbox & Settings
+
+- Network sandbox ON, filesystem relaxed (container isolation)
+- SOT: `~/.claude/settings.json`
+- Settings require session restart (no hot-reload)
+
+## Project Patterns
+
+<!-- Project-specific conventions, architecture notes -->
+
+## Learned Preferences
+
+<!-- Agent behavior corrections, confirmed approaches -->
+
+## Known Issues
+
+<!-- Active workarounds, known bugs, environment quirks -->

--- a/plugins/cc-meta/hooks/hooks.json
+++ b/plugins/cc-meta/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/setup-cc-meta.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/cc-meta/hooks/scripts/setup-cc-meta.sh
+++ b/plugins/cc-meta/hooks/scripts/setup-cc-meta.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+# Deploy MEMORY.md seed template (copy-if-not-exists)
+
+PLUGIN_DIR="$CLAUDE_PLUGIN_ROOT"
+DEPLOYED=()
+
+# MEMORY.md seed template
+TARGET="MEMORY.md"
+if [ ! -f "$TARGET" ]; then
+  cp "$PLUGIN_DIR/examples/memory/MEMORY.md" "$TARGET"
+  DEPLOYED+=("memory: MEMORY.md (seed template)")
+fi
+
+# Report
+if [ ${#DEPLOYED[@]} -gt 0 ]; then
+  echo "# CC Meta Setup"
+  echo ""
+  echo "Deployed ${#DEPLOYED[@]} file(s):"
+  for item in "${DEPLOYED[@]}"; do
+    echo "  - $item"
+  done
+fi


### PR DESCRIPTION
## Summary
- Add generic MEMORY.md seed template at `plugins/cc-meta/examples/memory/`
- Add SessionStart hook to deploy seed if no MEMORY.md exists (copy-if-not-exists)
- Idempotent: second run deploys nothing
- Bump cc-meta to 1.4.0

Closes #41

## Test plan
- [ ] `bash -n` passes on setup script
- [ ] JSON files validate
- [ ] Version 1.4.0 matches in plugin.json and marketplace.json
- [ ] First run in empty dir deploys MEMORY.md
- [ ] Second run produces no output (idempotent)
- [ ] Existing MEMORY.md is never overwritten

🤖 Generated with Claude <noreply@anthropic.com>