### PR TITLE
feat: add typescript-dev plugin with skills, rules, and best practices

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -121,6 +121,12 @@
       "source": "./plugins/cc-voice",
       "description": "E2E voice — TTS via PTY proxy (/speak), STT via Moonshine (/listen, planned). Prototype, git submodule.",
       "version": "0.2.0"
+    },
+    {
+      "name": "typescript-dev",
+      "source": "./plugins/typescript-dev",
+      "description": "TypeScript implementation, testing, and code review skills, deploys npm/vitest permissions via SessionStart hook",
+      "version": "1.0.0"
     }
   ]
 }

--- a/plugins/typescript-dev/.claude-plugin/plugin.json
+++ b/plugins/typescript-dev/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "typescript-dev",
+  "version": "1.0.0",
+  "description": "TypeScript implementation, testing, and code review skills, deploys npm/vitest permissions via SessionStart hook",
+  "author": { "name": "Claude Code Utils Contributors" },
+  "keywords": ["typescript", "react", "vitest", "vite", "implementation", "testing", "review"]
+}

--- a/plugins/typescript-dev/README.md
+++ b/plugins/typescript-dev/README.md
@@ -1,0 +1,20 @@
+# typescript-dev
+
+TypeScript implementation, testing, and code review skills, deploys npm/vitest permissions via SessionStart hook.
+
+## Skills
+
+- **implementing-typescript** — Implements concise, streamlined TypeScript/React code matching exact architect specifications
+- **testing-typescript** — Writes tests following TDD (using vitest and @testing-library/react) best practices
+- **reviewing-typescript** — Provides concise, focused TypeScript/React code reviews matching exact task complexity requirements
+
+## Deployed files
+
+- **settings.local.json** -> `.claude/settings.local.json` — npm/vitest permissions (if node detected, copy-if-not-exists)
+- **testing.md** -> `.claude/rules/testing.md` — vitest conventions (if node detected, copy-if-not-exists)
+
+## Install
+
+```bash
+claude plugin install typescript-dev@qte77-claude-code-utils
+```

--- a/plugins/typescript-dev/hooks/hooks.json
+++ b/plugins/typescript-dev/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/setup-typescript-dev.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/typescript-dev/hooks/scripts/setup-typescript-dev.sh
+++ b/plugins/typescript-dev/hooks/scripts/setup-typescript-dev.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+PLUGIN_DIR="$CLAUDE_PLUGIN_ROOT"
+DEPLOYED=()
+
+# Deploy npm/vitest permissions to .claude/settings.local.json (copy-if-not-exists)
+if command -v node >/dev/null 2>&1; then
+  TARGET=".claude/settings.local.json"
+  if [ ! -f "$TARGET" ]; then
+    mkdir -p .claude
+    cp "$PLUGIN_DIR/settings/settings.local.json" "$TARGET"
+    DEPLOYED+=("settings: settings.local.json (npm/vitest permissions)")
+  fi
+fi
+
+# Deploy testing rules to .claude/rules/testing.md (copy-if-not-exists)
+if command -v node >/dev/null 2>&1; then
+  TARGET=".claude/rules/testing.md"
+  if [ ! -f "$TARGET" ]; then
+    mkdir -p .claude/rules
+    cp "$PLUGIN_DIR/scaffold/rules/testing.md" "$TARGET"
+    DEPLOYED+=("rules: testing.md (vitest conventions)")
+  fi
+fi
+
+# Report
+if [ ${#DEPLOYED[@]} -gt 0 ]; then
+  echo "# TypeScript Dev Setup"
+  echo ""
+  echo "Deployed ${#DEPLOYED[@]} file(s):"
+  for item in "${DEPLOYED[@]}"; do
+    echo "  - $item"
+  done
+fi

--- a/plugins/typescript-dev/scaffold/rules/testing.md
+++ b/plugins/typescript-dev/scaffold/rules/testing.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "src/**/*.test.ts"
+  - "src/**/*.test.tsx"
+  - "tests/**/*.ts"
+---
+
+# Testing Rules (TypeScript)
+
+- Use vitest with @testing-library/react for component tests
+- Mock external dependencies with vi.mock()
+- Use jsdom environment for DOM tests
+- Mirror src/ structure in tests
+- Test behavior, not implementation details
+- Use Arrange-Act-Assert structure
+- Prefer userEvent over fireEvent for interactions

--- a/plugins/typescript-dev/settings/settings.local.json
+++ b/plugins/typescript-dev/settings/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test:*)",
+      "Bash(npm run dev:*)",
+      "Bash(npm run build:*)",
+      "Bash(npx vitest:*)",
+      "Bash(npx tsc:*)"
+    ]
+  }
+}

--- a/plugins/typescript-dev/skills/implementing-typescript/SKILL.md
+++ b/plugins/typescript-dev/skills/implementing-typescript/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: implementing-typescript
+description: Implements concise, streamlined TypeScript/React code matching exact architect specifications. Use when writing TypeScript code, creating modules, or when the user asks to implement features in TypeScript/React.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, Edit, Write, Bash, WebSearch, WebFetch
+  argument-hint: [feature-name]
+  stability: stable
+---
+
+# TypeScript Implementation
+
+**Target**: $ARGUMENTS
+
+Creates **focused, streamlined** TypeScript/React implementations following architect
+specifications exactly. No over-engineering.
+
+## TypeScript Standards
+
+See `references/typescript-best-practices.md` for comprehensive TypeScript guidelines.
+See `references/react-best-practices.md` for React patterns.
+See `references/vite-conventions.md` for Vite project conventions.
+
+## Workflow
+
+1. **Read architect specifications** from provided documents
+2. **Validate scope** — Simple (single module) vs Complex (multi-module)
+3. **Study existing patterns** in `src/` structure
+4. **Implement minimal solution** matching stated functionality
+5. **Create focused tests** matching task complexity
+6. **Run validation** and fix all issues
+
+## Implementation Strategy
+
+**Simple Tasks**: Single module, strict TypeScript, proper typing, inline exports
+
+**Complex Tasks**: Multi-module with React components, async patterns, proper interfaces, custom hooks
+
+**Always**: Use existing project patterns, pass validation
+
+## Output Standards
+
+**Simple Tasks**: Minimal functions with proper type annotations and error handling
+**Complex Tasks**: Complete modules with interfaces, components, tests, and documentation
+**All outputs**: Concise, streamlined, no unnecessary complexity
+
+## Quality Checks
+
+Before completing any task:
+
+```bash
+npx tsc --noEmit && npx vitest run && npx eslint .
+```
+
+All type checks, tests, and lints must pass.

--- a/plugins/typescript-dev/skills/implementing-typescript/references/react-best-practices.md
+++ b/plugins/typescript-dev/skills/implementing-typescript/references/react-best-practices.md
@@ -1,0 +1,153 @@
+---
+title: React Best Practices Reference
+version: 1.0
+applies-to: Agents and humans
+purpose: Modern React patterns with functional components, hooks, and accessibility
+see-also: typescript-best-practices.md, vite-conventions.md
+---
+
+## Components
+
+### Functional Components Only
+
+```tsx
+interface UserCardProps {
+  user: User;
+  onSelect: (id: string) => void;
+}
+
+export function UserCard({ user, onSelect }: UserCardProps) {
+  return (
+    <button onClick={() => onSelect(user.id)} type="button">
+      {user.name}
+    </button>
+  );
+}
+```
+
+Always type props with an interface. Never use class components.
+
+### Component Organization
+
+```typescript
+// 1. Types/interfaces
+// 2. Component function
+// 3. Internal helpers (below component)
+// One component per file (collocate sub-components if small)
+```
+
+## Hooks
+
+### Custom Hook Extraction
+
+Extract shared logic into custom hooks:
+
+```typescript
+function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+  return debounced;
+}
+```
+
+### useEffect Dependency Arrays
+
+```typescript
+// GOOD — all dependencies listed, cleanup returned
+useEffect(() => {
+  const controller = new AbortController();
+  fetchData(id, { signal: controller.signal }).then(setData);
+  return () => controller.abort();
+}, [id]);
+
+// BAD — missing dependency, stale closure
+useEffect(() => {
+  fetchData(id).then(setData);
+}, []); // eslint will warn about missing 'id'
+```
+
+### Memoization Guidance
+
+```typescript
+// DO use when: passing callbacks to memoized children, expensive computations
+const handleSubmit = useCallback((data: FormData) => {
+  submitForm(data);
+}, [submitForm]);
+
+// DON'T use for: simple values, inline functions in non-memoized components
+// Premature memoization adds complexity without benefit
+```
+
+## State Management
+
+### Local State First
+
+Start with `useState`. Lift state up only when shared. Reach for context or
+external stores only when prop drilling becomes painful.
+
+```typescript
+// Simple state
+const [count, setCount] = useState(0);
+
+// Complex state — useReducer
+const [state, dispatch] = useReducer(reducer, initialState);
+```
+
+### React 19 Patterns
+
+```typescript
+// use() for promises and context
+const data = use(dataPromise);
+
+// Actions for form handling
+async function createAction(formData: FormData) {
+  'use server';
+  await saveToDb(formData);
+}
+```
+
+## Keys
+
+```tsx
+// GOOD — stable, unique identifier
+{items.map((item) => <ListItem key={item.id} item={item} />)}
+
+// BAD — array index (breaks on reorder/filter)
+{items.map((item, i) => <ListItem key={i} item={item} />)}
+```
+
+## Accessibility
+
+### Semantic HTML
+
+```tsx
+// GOOD — semantic elements
+<nav aria-label="Main navigation">
+  <button type="button" onClick={toggle}>Menu</button>
+</nav>
+
+// BAD — div soup
+<div onClick={toggle}>Menu</div>
+```
+
+### Required Practices
+
+- All interactive elements keyboard-accessible (tab, enter, escape)
+- Images have `alt` text (decorative: `alt=""`)
+- Form inputs have associated `<label>` elements
+- ARIA attributes for dynamic content (`aria-live`, `aria-expanded`)
+- Color contrast meets WCAG AA (4.5:1 text, 3:1 large text)
+
+## Common Mistakes
+
+| Mistake | Impact | Fix |
+|---------|--------|-----|
+| Missing key prop | Broken reconciliation | Use stable unique id |
+| Object/array in deps | Infinite re-renders | Memoize or restructure |
+| State for derived data | Stale values | Compute during render |
+| Missing cleanup in useEffect | Memory leaks | Return cleanup function |
+| Non-interactive div with onClick | Inaccessible | Use `<button>` |
+| Index as key | Broken reorder | Use stable id |

--- a/plugins/typescript-dev/skills/implementing-typescript/references/typescript-best-practices.md
+++ b/plugins/typescript-dev/skills/implementing-typescript/references/typescript-best-practices.md
@@ -1,0 +1,209 @@
+---
+title: TypeScript Best Practices Reference
+version: 1.0
+applies-to: Agents and humans
+purpose: Type-safe TypeScript coding standards with strict mode and modern patterns
+see-also: react-best-practices.md, vite-conventions.md
+---
+
+## Strict Mode (Non-Negotiable)
+
+### tsconfig.json Essentials
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "target": "ES2022",
+    "isolatedModules": true,
+    "skipLibCheck": true
+  }
+}
+```
+
+All projects must use `strict: true`. Never disable individual strict checks.
+
+### Secrets Management
+
+```typescript
+const config = {
+  apiKey: process.env.API_KEY ?? throwEnvError('API_KEY'),
+  dbUrl: process.env.DATABASE_URL ?? throwEnvError('DATABASE_URL'),
+};
+
+function throwEnvError(name: string): never {
+  throw new Error(`Missing environment variable: ${name}`);
+}
+```
+
+Never hardcode credentials in source code.
+
+## Type System
+
+### Prefer unknown Over any
+
+```typescript
+// BAD — disables type checking
+function parse(input: any): User { ... }
+
+// GOOD — forces type narrowing
+function parse(input: unknown): User {
+  if (!isUser(input)) throw new TypeError('Invalid user data');
+  return input;
+}
+```
+
+### Type Guards Over Casts
+
+```typescript
+// BAD — bypasses type checking
+const user = data as User;
+
+// GOOD — runtime validation
+function isUser(data: unknown): data is User {
+  return typeof data === 'object' && data !== null && 'id' in data;
+}
+```
+
+### Discriminated Unions
+
+Model exclusive states with a literal discriminant:
+
+```typescript
+type RequestState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: User[] }
+  | { status: 'error'; error: string };
+```
+
+The compiler enforces exhaustive handling with `switch` on `status`.
+
+### Proper Null Handling
+
+```typescript
+// Use nullish coalescing and optional chaining
+const name = user?.profile?.displayName ?? 'Anonymous';
+
+// Use strict null checks — never assume values exist
+function getItem(id: string): Item | undefined { ... }
+```
+
+## Error Handling
+
+### Result Pattern (for expected errors)
+
+```typescript
+type Result<T, E = Error> = { ok: true; value: T } | { ok: false; error: E };
+
+function parseConfig(raw: string): Result<Config> {
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch (e) {
+    return { ok: false, error: new Error('Invalid config JSON') };
+  }
+}
+```
+
+### Try/Catch (for unexpected errors)
+
+```typescript
+async function fetchUser(id: string): Promise<User> {
+  const res = await fetch(`/api/users/${id}`);
+  if (!res.ok) throw new HttpError(res.status, await res.text());
+  return res.json() as Promise<User>;
+}
+```
+
+## Modules and Imports
+
+### ESM-First
+
+```typescript
+// Named exports preferred
+export function createUser(data: UserInput): User { ... }
+export type { User, UserInput };
+
+// Avoid default exports (harder to refactor, inconsistent naming)
+```
+
+### Import Order
+
+```typescript
+// 1. Node/framework builtins
+import { useEffect } from 'react';
+// 2. External packages
+import { z } from 'zod';
+// 3. Internal modules
+import { createUser } from '@/services/user';
+// 4. Types
+import type { User } from '@/types';
+```
+
+## Generics
+
+```typescript
+// Constrained generics for type-safe utilities
+function groupBy<T, K extends string>(items: T[], key: (item: T) => K): Record<K, T[]> { ... }
+
+// Inferred generics — let TypeScript infer when possible
+const result = groupBy(users, (u) => u.role);
+```
+
+## Async Patterns
+
+### Promise.allSettled for Concurrent Operations
+
+```typescript
+const results = await Promise.allSettled([
+  fetchUser(id),
+  fetchOrders(id),
+  fetchPreferences(id),
+]);
+
+const [user, orders, prefs] = results.map((r) =>
+  r.status === 'fulfilled' ? r.value : null
+);
+```
+
+### AbortController for Cancellation
+
+```typescript
+const controller = new AbortController();
+const res = await fetch(url, { signal: controller.signal });
+```
+
+## Common Mistakes
+
+| Mistake | Impact | Fix |
+|---------|--------|-----|
+| Using `any` | Disables type safety | Use `unknown` + type guards |
+| Type assertions (`as`) | Bypasses checking | Use type guards |
+| Missing `noUncheckedIndexedAccess` | Silent undefined | Enable in tsconfig |
+| Barrel imports of large libs | Bundle bloat | Import specific modules |
+| `!` non-null assertion | Runtime errors | Handle null/undefined properly |
+| Enum (numeric) | Loose typing | Use `as const` objects or unions |
+| `export default` | Refactoring hazard | Use named exports |
+
+## Pre-Commit Checklist
+
+### Type Safety
+- [ ] No `any` types in production code
+- [ ] `strict: true` enabled
+- [ ] No type assertions without justification
+- [ ] Discriminated unions for state variants
+
+### Code Quality
+- [ ] Named exports used consistently
+- [ ] ESM imports with proper ordering
+- [ ] No hardcoded secrets or credentials
+- [ ] All external input validated at boundaries
+
+### Testing and Validation
+- [ ] Unit tests for new logic
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npx vitest run` passes
+- [ ] `npx eslint .` passes

--- a/plugins/typescript-dev/skills/implementing-typescript/references/vite-conventions.md
+++ b/plugins/typescript-dev/skills/implementing-typescript/references/vite-conventions.md
@@ -1,0 +1,127 @@
+---
+title: Vite Conventions Reference
+version: 1.0
+applies-to: Agents and humans
+purpose: Vite project structure, configuration, and deployment conventions
+see-also: typescript-best-practices.md, react-best-practices.md
+---
+
+## Project Structure
+
+```text
+├── public/              # Static assets (served as-is)
+├── src/
+│   ├── assets/          # Processed assets (imported in code)
+│   ├── components/      # Shared React components
+│   ├── hooks/           # Custom hooks
+│   ├── lib/             # Utilities and helpers
+│   ├── pages/           # Route-level components
+│   ├── types/           # Shared TypeScript types
+│   ├── App.tsx          # Root component
+│   └── main.tsx         # Entry point
+├── index.html           # HTML entry (Vite serves this)
+├── vite.config.ts
+├── tsconfig.json
+└── package.json
+```
+
+## Configuration
+
+### vite.config.ts
+
+```typescript
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: { '@': '/src' },
+  },
+});
+```
+
+### Path Aliases
+
+Configure in both `vite.config.ts` and `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "paths": { "@/*": ["./src/*"] }
+  }
+}
+```
+
+Use `@/` prefix for all internal imports: `import { Button } from '@/components/Button'`.
+
+## Environment Variables
+
+### Access Pattern
+
+```typescript
+// Vite exposes variables prefixed with VITE_
+const apiUrl = import.meta.env.VITE_API_URL;
+
+// Type-safe env
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+  readonly VITE_APP_TITLE: string;
+}
+```
+
+### .env Files
+
+```text
+.env                # Shared defaults
+.env.local          # Local overrides (gitignored)
+.env.production     # Production values
+```
+
+Never prefix secrets with `VITE_` — they are embedded in the client bundle.
+
+## Build and Deployment
+
+### Base Path
+
+```typescript
+// For subdirectory deployment (e.g., GitHub Pages)
+export default defineConfig({
+  base: '/my-repo/',
+});
+```
+
+### Build Output
+
+```bash
+npx vite build          # Output to dist/
+npx vite preview        # Preview production build locally
+```
+
+## Tailwind CSS v4 (Vite Plugin)
+
+```typescript
+// vite.config.ts — use @tailwindcss/vite plugin (v4)
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+});
+```
+
+```css
+/* src/index.css — v4 uses @import instead of @tailwind directives */
+@import 'tailwindcss';
+```
+
+No `tailwind.config.js` needed in v4 — configure via CSS `@theme`.
+
+## Common Mistakes
+
+| Mistake | Impact | Fix |
+|---------|--------|-----|
+| Secret in `VITE_` var | Leaked to client | Use server-side env only |
+| Missing `base` for subpath | Broken asset paths | Set `base` in config |
+| Wrong alias in tsconfig | TS errors despite Vite working | Sync both configs |
+| `tailwind.config.js` with v4 | Ignored config | Use CSS `@theme` blocks |

--- a/plugins/typescript-dev/skills/reviewing-typescript/SKILL.md
+++ b/plugins/typescript-dev/skills/reviewing-typescript/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: reviewing-typescript
+description: Provides concise, focused TypeScript/React code reviews matching exact task complexity requirements. Use when reviewing TypeScript code quality, type safety, or when the user asks for code review.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, WebFetch, WebSearch
+  argument-hint: [file-or-directory]
+  stability: stable
+---
+
+# Review Context
+
+- Changed files: !`git diff --name-only HEAD~1 2>/dev/null || echo "No recent commits"`
+- Staged files: !`git diff --staged --name-only`
+
+## Code Review
+
+**Scope**: $ARGUMENTS
+
+Delivers **focused, streamlined** TypeScript/React code reviews matching stated task
+requirements exactly. No over-analysis.
+
+## TypeScript Standards
+
+See `references/typescript-best-practices.md` for comprehensive TypeScript guidelines.
+
+## Workflow
+
+1. **Read task requirements** to understand expected scope
+2. **Check validation passes** before detailed review
+3. **Match review depth** to task complexity (simple vs complex)
+4. **Validate requirements** — does implementation match task scope exactly?
+5. **Issue focused feedback** with specific file paths and line numbers
+
+## Review Strategy
+
+**Simple Tasks (single module)**: Type safety, error handling, requirements match,
+basic quality
+
+**Complex Tasks (multi-module)**: Above plus architecture, React patterns,
+async correctness, comprehensive testing
+
+**Always**: Use existing project patterns, check for `any` types
+
+## Review Checklist
+
+**Type Safety & Security**:
+
+- [ ] No `any` types (use `unknown` with type guards)
+- [ ] Proper generics and discriminated unions
+- [ ] All external input validated at boundaries
+- [ ] No secrets or credentials in source code
+
+**React Patterns**:
+
+- [ ] No unnecessary re-renders (proper memoization only when needed)
+- [ ] Correct useEffect dependency arrays
+- [ ] Custom hooks extracted for shared logic
+- [ ] Accessibility: semantic HTML, ARIA attributes, keyboard navigation
+
+**Bundle & Performance**:
+
+- [ ] No barrel imports of large libraries (import specific modules)
+- [ ] Dynamic imports for heavy components
+- [ ] No blocking operations in render path
+
+**Requirements Match**:
+
+- [ ] Implements exactly what was requested
+- [ ] No over-engineering or scope creep
+- [ ] Appropriate complexity level
+
+**Code Quality**:
+
+- [ ] Follows project patterns in `src/`
+- [ ] Proper error handling with Result types or try/catch
+- [ ] Tests cover stated functionality
+- [ ] ESM imports used consistently
+
+**Structural Health**:
+
+- [ ] No function exceeds cognitive complexity threshold
+- [ ] No copy-paste duplication across modules
+- [ ] Barrel exports used sparingly and intentionally
+
+## Output Standards
+
+**Simple Tasks**: CRITICAL issues only, clear approval when requirements met
+**Complex Tasks**: CRITICAL/WARNINGS/SUGGESTIONS with specific fixes
+**All reviews**: Concise, streamlined, no unnecessary complexity analysis

--- a/plugins/typescript-dev/skills/reviewing-typescript/references/typescript-best-practices.md
+++ b/plugins/typescript-dev/skills/reviewing-typescript/references/typescript-best-practices.md
@@ -1,0 +1,1 @@
+../../implementing-typescript/references/typescript-best-practices.md

--- a/plugins/typescript-dev/skills/testing-typescript/SKILL.md
+++ b/plugins/typescript-dev/skills/testing-typescript/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: testing-typescript
+description: Writes tests following TDD (using vitest and @testing-library/react) best practices. Use when writing unit tests, integration tests, or component tests in TypeScript.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, Edit, Write, Bash
+  argument-hint: [test-scope or component-name]
+  stability: stable
+---
+
+# TypeScript Testing
+
+**Target**: $ARGUMENTS
+
+Writes **focused, behavior-driven tests** following project testing strategy.
+
+## Quick Reference
+
+**TDD methodology** (language-agnostic): See `tdd-core` plugin (`testing-tdd` skill)
+
+**TypeScript-specific documentation**: `references/`
+
+- `references/testing-strategy-ts.md` — TypeScript tools (vitest, @testing-library/react, MSW)
+- `references/tdd-best-practices-ts.md` — TypeScript TDD examples (extends tdd-core)
+
+## Quick Decision
+
+**vitest (default)**: Use `it`/`test` for known cases, `vi.mock` for module mocking. Works at unit/integration levels.
+
+**@testing-library/react (components)**: Use for React component behavior testing with render, screen, userEvent.
+
+See `references/testing-strategy-ts.md` for full methodology comparison.
+
+## TDD Essentials (Quick Reference)
+
+**Cycle**: RED (failing test / type error) -> GREEN (minimal pass) -> REFACTOR (clean up)
+
+**Structure**: Arrange-Act-Assert (AAA)
+
+```typescript
+it('calculates order total from item prices', () => {
+  // ARRANGE
+  const items = [{ price: 10, qty: 2 }, { price: 5, qty: 1 }];
+  const calculator = new OrderCalculator();
+
+  // ACT
+  const total = calculator.total(items);
+
+  // ASSERT
+  expect(total).toBe(25);
+});
+```
+
+## Component Testing Priorities
+
+| Priority | Area | Example |
+| -------- | ---- | ------- |
+| CRITICAL | User interactions | Button click triggers handler |
+| CRITICAL | Conditional rendering | Error state shows message |
+| HIGH | Form validation | Invalid input shows error |
+| HIGH | Async data loading | Loading -> success/error states |
+
+## What to Test (KISS/DRY/YAGNI)
+
+**High-Value**: Business logic, error paths, component behavior, async flows, custom hooks
+
+**Avoid**: Type system behavior, library internals, CSS styling, implementation details
+
+See `references/testing-strategy-ts.md` -> "Patterns to Remove" for full list.
+
+## Naming Convention
+
+**Format**: `{module} > {component} > {behavior}`
+
+```typescript
+describe('UserService', () => {
+  it('creates a new user with valid data', () => { ... });
+  it('rejects duplicate email addresses', () => { ... });
+});
+```
+
+## Execution
+
+```bash
+npx vitest                          # Watch mode (default)
+npx vitest run                      # Single run
+npx vitest run src/utils            # Filter by path
+npx vitest run --reporter=verbose   # Verbose output
+npx vitest --ui                     # Browser UI
+```
+
+## Quality Gates
+
+- [ ] All tests pass (`npx vitest run`)
+- [ ] TDD Red-Green-Refactor followed
+- [ ] Arrange-Act-Assert structure used
+- [ ] Naming convention followed
+- [ ] Behavior-focused (not implementation)
+- [ ] No library/framework behavior tested
+- [ ] Mocks use `vi.mock()` with proper restore (`vi.restoreAllMocks()`)

--- a/plugins/typescript-dev/skills/testing-typescript/references/tdd-best-practices-ts.md
+++ b/plugins/typescript-dev/skills/testing-typescript/references/tdd-best-practices-ts.md
@@ -1,0 +1,159 @@
+---
+title: TDD Best Practices (TypeScript)
+version: 1.0
+based-on: Industry research 2025-2026
+see-also: testing-strategy-ts.md
+---
+
+**Purpose**: TypeScript-specific TDD examples with vitest and @testing-library/react.
+
+> Language-agnostic TDD principles (cycle, AAA, anti-patterns) are in
+> the `tdd-core` plugin. This file extends those with TypeScript tooling.
+
+## Red-Green-Refactor with vitest
+
+In TypeScript, the RED phase often starts with a **type error** — the
+function does not exist yet. That is intentional. Write the test first,
+let the compiler tell you what is missing.
+
+## AAA Structure in TypeScript Tests
+
+```typescript
+it('calculates order total from item prices', () => {
+  // ARRANGE
+  const items = [{ price: 10, qty: 2 }, { price: 5, qty: 1 }];
+  const calculator = new OrderCalculator();
+
+  // ACT
+  const total = calculator.total(items);
+
+  // ASSERT
+  expect(total).toBe(25);
+});
+```
+
+## TypeScript-Specific TDD: Type Guard
+
+**RED** — write the test, it won't compile:
+
+```typescript
+it('rejects invalid email strings', () => {
+  const result = parseEmail('notanemail');
+  expect(result.ok).toBe(false);
+});
+```
+
+**GREEN** — minimal implementation:
+
+```typescript
+type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+function parseEmail(input: string): Result<string> {
+  if (input.includes('@')) {
+    return { ok: true, value: input };
+  }
+  return { ok: false, error: 'Missing @' };
+}
+```
+
+**REFACTOR** — improve without breaking tests.
+
+## React Component TDD
+
+**RED** — write the test first:
+
+```typescript
+it('displays greeting with user name', () => {
+  render(<Greeting name="Alice" />);
+  expect(screen.getByText('Hello, Alice!')).toBeInTheDocument();
+});
+```
+
+**GREEN** — minimal component:
+
+```tsx
+interface GreetingProps { name: string; }
+
+export function Greeting({ name }: GreetingProps) {
+  return <p>Hello, {name}!</p>;
+}
+```
+
+**REFACTOR** — extract shared patterns, improve accessibility.
+
+## Custom Hook TDD
+
+**RED** — write the test:
+
+```typescript
+import { renderHook, act } from '@testing-library/react';
+
+it('toggles between true and false', () => {
+  const { result } = renderHook(() => useToggle(false));
+
+  act(() => result.current.toggle());
+
+  expect(result.current.value).toBe(true);
+});
+```
+
+**GREEN** — minimal hook:
+
+```typescript
+function useToggle(initial: boolean) {
+  const [value, setValue] = useState(initial);
+  const toggle = useCallback(() => setValue((v) => !v), []);
+  return { value, toggle };
+}
+```
+
+## Anti-Patterns
+
+### Testing implementation details
+
+```typescript
+// BAD — tests internal state shape
+expect(component.state.items.length).toBe(3);
+
+// GOOD — tests observable behavior
+expect(screen.getAllByRole('listitem')).toHaveLength(3);
+```
+
+### Snapshot abuse
+
+```typescript
+// BAD — brittle, noisy diffs on any change
+expect(container).toMatchSnapshot();
+
+// GOOD — assert specific behavior
+expect(screen.getByRole('heading')).toHaveTextContent('Dashboard');
+```
+
+### Over-mocking
+
+```typescript
+// BAD — mocking everything, testing nothing
+vi.mock('./utils');
+vi.mock('./api');
+vi.mock('./hooks');
+
+// GOOD — mock only external boundaries
+vi.mock('./api');  // external dependency only
+```
+
+## When to Use TDD in TypeScript
+
+**Use TDD for**: Business logic, custom hooks, form validation,
+async service logic, utility functions, component behavior
+
+**Consider alternatives for**: Visual layout (use Storybook), complex animations,
+one-off scripts, exploratory prototypes
+
+## Running Tests During TDD
+
+```bash
+npx vitest                              # Watch mode (default)
+npx vitest run src/utils/email.test.ts  # Single file
+npx vitest run --reporter=verbose       # Show all test names
+npx tsc --noEmit && npx vitest run      # Pre-commit
+```

--- a/plugins/typescript-dev/skills/testing-typescript/references/testing-strategy-ts.md
+++ b/plugins/typescript-dev/skills/testing-typescript/references/testing-strategy-ts.md
@@ -1,0 +1,201 @@
+---
+title: Testing Strategy (TypeScript)
+version: 1.0
+applies-to: Agents and humans
+purpose: TypeScript-specific testing tools and when to use each
+see-also: tdd-best-practices-ts.md
+---
+
+**Purpose**: TypeScript-specific testing tools and when to use each.
+
+> Language-agnostic testing strategy (what to test, mocking, organization)
+> is in the `tdd-core` plugin. This file extends it with TypeScript tools
+> (vitest, @testing-library/react, MSW).
+
+## Core Principles
+
+| Principle | Testing Application |
+|-----------|---------------------|
+| **KISS** | Test behavior, not implementation details |
+| **DRY** | No duplicate coverage across tests |
+| **YAGNI** | Don't test framework or library behavior |
+
+## What to Test
+
+**High-Value** (test these):
+
+1. Business logic — algorithms, calculations, decision rules
+2. Error paths — thrown errors, rejected promises, edge cases
+3. Component behavior — user interactions, conditional rendering
+4. Integration points — API contracts, serialization, custom hooks
+
+**Low-Value** (avoid these):
+
+1. Framework mechanics — React renders, router navigates
+2. Trivial getters/setters — unless they encode business rules
+3. Type system — TypeScript already verifies types at compile time
+4. CSS styling — visual regressions need screenshot tools, not unit tests
+
+### Patterns to Remove
+
+| Pattern | Why Remove | Example |
+|---------|------------|---------|
+| Type checks | TypeScript verifies | `expect(typeof x).toBe('string')` |
+| Snapshot abuse | Brittle, noisy diffs | Snapshot of entire page component |
+| Library wrappers | Testing the library | `expect(useState).toBeDefined()` |
+| Over-granular | Consolidate | 6 tests for one component's props |
+
+**Rule**: If the test wouldn't catch a real bug, remove it.
+
+## Tool Selection Guide
+
+| Tool | Question it answers | Use for |
+|------|---------------------|---------|
+| **vitest** | Does this logic produce the right result? | TDD, unit, integration |
+| **@testing-library/react** | Does this component behave correctly? | Component interactions |
+| **MSW** | Does this work with real API shapes? | API mocking at network level |
+| **vi.mock** | Does this behave in isolation? | Module-level mocking |
+
+**One-line rule**: vitest for **logic**, testing-library for **components**, MSW for **APIs**, vi.mock for **isolation**.
+
+## Unit Tests
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { calculateTotal } from './order';
+
+describe('calculateTotal', () => {
+  it('sums item prices multiplied by quantity', () => {
+    const items = [{ price: 10, qty: 2 }, { price: 5, qty: 1 }];
+    expect(calculateTotal(items)).toBe(25);
+  });
+});
+```
+
+## Component Tests with @testing-library/react
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Counter } from './Counter';
+
+it('increments count on button click', async () => {
+  const user = userEvent.setup();
+  render(<Counter />);
+
+  await user.click(screen.getByRole('button', { name: /increment/i }));
+
+  expect(screen.getByText('Count: 1')).toBeInTheDocument();
+});
+```
+
+### Query Priority
+
+1. `getByRole` — accessible queries (preferred)
+2. `getByLabelText` — form elements
+3. `getByText` — visible text
+4. `getByTestId` — last resort only
+
+### Async Patterns
+
+```typescript
+// Wait for element to appear
+await screen.findByText('Loaded');
+
+// Wait for element to disappear
+await waitFor(() => {
+  expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+});
+```
+
+## API Mocking with MSW
+
+```typescript
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+const server = setupServer(
+  http.get('/api/users/:id', ({ params }) => {
+    return HttpResponse.json({ id: params.id, name: 'Alice' });
+  })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+**When to use MSW**: API integrations, error responses, loading states
+**When NOT to use**: Pure logic tests, simple component rendering
+
+## Module Mocking with vi.mock
+
+```typescript
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('./api', () => ({
+  fetchUser: vi.fn().mockResolvedValue({ id: '1', name: 'Alice' }),
+}));
+```
+
+Always call `vi.restoreAllMocks()` in `afterEach`.
+
+## Vitest Configuration
+
+```typescript
+// vitest.config.ts (or in vite.config.ts)
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+  },
+});
+```
+
+```typescript
+// src/test/setup.ts
+import '@testing-library/jest-dom/vitest';
+```
+
+## Test Organization
+
+```text
+src/
+├── components/
+│   ├── Button.tsx
+│   └── Button.test.tsx    (colocated)
+├── lib/
+│   ├── utils.ts
+│   └── utils.test.ts      (colocated)
+└── test/
+    ├── setup.ts            (global setup)
+    └── mocks/              (shared MSW handlers)
+```
+
+## Naming Conventions
+
+**Format**: `describe('{Module}') > it('{behavior}')`
+
+```typescript
+describe('OrderCalculator', () => {
+  it('sums item prices', () => { ... });
+  it('applies percentage discount', () => { ... });
+});
+```
+
+## Decision Checklist
+
+1. Does this test **behavior** (keep) or **implementation** (skip)?
+2. Would this catch a **real bug** (keep) or is it **trivial** (skip)?
+3. Is this testing **our code** (keep) or **framework/library** (skip)?
+4. Which tool: vitest (default), testing-library (components), MSW (APIs), vi.mock (isolation)
+
+## References
+
+- TDD practices: `tdd-best-practices-ts.md`
+- [Vitest Documentation](https://vitest.dev/)
+- [Testing Library Docs](https://testing-library.com/docs/react-testing-library/intro)
+- [MSW Documentation](https://mswjs.io/)


### PR DESCRIPTION
## Summary
- New `typescript-dev` plugin (16 files) following rust-dev/go-dev pattern
- 3 skills: implementing-typescript, testing-typescript, reviewing-typescript
- 5 reference files: TS best practices, React, Vite, testing strategy, TDD examples
- SessionStart hook deploys npm/vitest permissions and testing rules when `node` detected
- Symlink for reviewing reference (DRY with implementing)
- Registered in marketplace.json at version 1.0.0

Closes #63

## Test plan
- [ ] All JSON files validate (`python3 -m json.tool`)
- [ ] `bash -n` passes on setup script
- [ ] Symlink resolves: `readlink plugins/typescript-dev/skills/reviewing-typescript/references/typescript-best-practices.md`
- [ ] Version 1.0.0 matches in plugin.json and marketplace.json
- [ ] Setup script deploys settings when `node` is available

🤖 Generated with Claude <noreply@anthropic.com>