### PR TITLE
feat(workspace): add context7 MCP tool permissions to setup/sandbox

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,13 +72,13 @@
       "name": "workspace-setup",
       "source": "./plugins/workspace-setup",
       "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     {
       "name": "workspace-sandbox",
       "source": "./plugins/workspace-sandbox",
       "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     {
       "name": "docs-governance",

--- a/plugins/workspace-sandbox/.claude-plugin/plugin.json
+++ b/plugins/workspace-sandbox/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-sandbox",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "sandbox", "read-once"]

--- a/plugins/workspace-sandbox/settings/settings-sandbox.json
+++ b/plugins/workspace-sandbox/settings/settings-sandbox.json
@@ -60,6 +60,8 @@
       "Edit(tests/)",
       "Edit(src/**)",
       "mcp__ide__getDiagnostics",
+      "mcp__plugin_context7_context7__resolve-library-id",
+      "mcp__plugin_context7_context7__query-docs",
       "Read(.claude/skills/)",
       "Read(.claude/rules/)",
       "SlashCommand",

--- a/plugins/workspace-setup/.claude-plugin/plugin.json
+++ b/plugins/workspace-setup/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-setup",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "governance", "setup", "read-once"]

--- a/plugins/workspace-setup/settings/settings-base.json
+++ b/plugins/workspace-setup/settings/settings-base.json
@@ -31,6 +31,8 @@
       "Edit(tests/)",
       "Edit(src/**)",
       "mcp__ide__getDiagnostics",
+      "mcp__plugin_context7_context7__resolve-library-id",
+      "mcp__plugin_context7_context7__query-docs",
       "Read(.claude/skills/)",
       "Read(.claude/rules/)",
       "SlashCommand",


### PR DESCRIPTION
## Summary
- Add `mcp__plugin_context7_context7__resolve-library-id` and `mcp__plugin_context7_context7__query-docs` to both workspace-setup and workspace-sandbox settings
- context7 plugin was already enabled but tools required manual permission grants
- Bump workspace-setup and workspace-sandbox to 1.3.2

## Test plan
- [ ] JSON files validate
- [ ] Versions match (1.3.2) in plugin.json and marketplace.json
- [ ] New workspaces using these plugins get context7 tools auto-allowed

🤖 Generated with Claude <noreply@anthropic.com>