### PR TITLE
feat(cc-meta): session-summaries + plan-learnings distiller

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
       "name": "cc-meta",
       "source": "./plugins/cc-meta",
       "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     {
       "name": "backend-design",

--- a/plugins/cc-meta/.claude-plugin/plugin.json
+++ b/plugins/cc-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-meta",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["meta", "big-picture", "synthesis", "context", "compaction", "sessions", "plans", "reasoning-modes"]

--- a/plugins/cc-meta/README.md
+++ b/plugins/cc-meta/README.md
@@ -5,6 +5,7 @@ Claude Code meta-skills for cross-project synthesis and session intelligence.
 ## Skills
 
 - **synthesizing-cc-bigpicture** — Synthesizes a living meta-plan across Claude Code sessions, plans, tasks, and team communications. Surfaces reasoning modes (diverge/converge, inductive/deductive, top-down/bottom-up) per work stream and project-arching TODOs/DONEs.
+- **distilling-plan-learnings** — Extracts decisions, rejected alternatives, and patterns from recent plans into a persistent learnings document. Use after completing a plan or sprint.
 - **compacting-context** — Distills verbose outputs into structured summaries following ACE-FCA principles. Use after pollution sources (searches, logs, JSON) or at phase milestones.
 
 ## Usage

--- a/plugins/cc-meta/skills/distilling-plan-learnings/SKILL.md
+++ b/plugins/cc-meta/skills/distilling-plan-learnings/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: distilling-plan-learnings
+description: Extracts decisions, rejected alternatives, and patterns from recent plans into a persistent learnings document. Use after completing a plan or sprint.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, Edit, Write
+  argument-hint: [time-range] [output-path]
+  context: fork
+  stability: development
+---
+
+# Plan-to-Learnings Distiller
+
+**Target**: $ARGUMENTS
+
+Extracts structured learnings from Claude Code plan files. Distills decisions
+made, alternatives rejected, and patterns discovered into a persistent document
+that compounds project knowledge over time.
+
+## Arguments
+
+| Position | Name | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| 1 | `time-range` | no | `7d` | E.g. `7d`, `30d`, `this-week`. Filter plans by modification time. |
+| 2 | `output-path` | no | `docs/learnings/from-plans.md` | Where to write/append output. |
+
+**Examples:**
+
+```
+/distilling-plan-learnings                          # Last 7 days → docs/learnings/from-plans.md
+/distilling-plan-learnings 30d                      # Last 30 days
+/distilling-plan-learnings 7d ./my-learnings.md     # Custom output path
+```
+
+## Data Source
+
+```
+~/.claude/
+├── plans/*.md                       # Plan mode files (filtered by mtime)
+```
+
+## When to Use
+
+- After completing a plan or sprint — capture what was learned
+- At week/sprint boundaries — accumulate decision history
+- Before starting a new plan — review past decisions and patterns
+
+## Do Not Use
+
+- For real-time plan editing (use plan mode directly)
+- For cross-project synthesis (use `/synthesizing-cc-bigpicture`)
+- For session-level context (use session-memory)
+
+## Workflow
+
+1. **Parse arguments** — Apply defaults per Arguments table. Resolve output path.
+   Create parent directories if needed.
+
+2. **Glob plans** — Glob `~/.claude/plans/*.md`. Filter by modification time
+   against the `time-range` argument. Sort by mtime descending (newest first).
+   If no plans match, report "No plans found in time range" and stop.
+
+3. **Read each plan** — Read matching plan files sequentially. Extract content
+   sections, noting plan title and date.
+
+4. **Extract learnings** into three categories:
+
+   - **Decisions made** — Choices that were committed to. Look for: selected
+     approaches, accepted trade-offs, finalized designs, chosen tools/patterns.
+   - **Alternatives rejected** — Options considered but not chosen. Look for:
+     crossed-out items, "decided against", "considered but", trade-off
+     discussions, pros/cons where one side won.
+   - **Patterns discovered** — Recurring themes or insights. Look for: repeated
+     blockers, successful strategies, workflow improvements, reusable solutions.
+
+5. **Format output** — Structure with date headers per plan. Group by category
+   within each plan section.
+
+6. **Write or append** — If output file exists, append new entries below
+   existing content with a separator. If new, write with header.
+
+## Output Format
+
+```markdown
+# Learnings from Plans
+
+## <Plan Title> — <YYYY-MM-DD>
+
+### Decisions Made
+- <decision>: <rationale>
+
+### Alternatives Rejected
+- <alternative>: <why rejected>
+
+### Patterns Discovered
+- <pattern>: <context and implication>
+
+---
+```
+
+## Common Pitfalls
+
+- **Inventing learnings**: Only extract what is explicitly stated or strongly
+  implied in plan text. Do not infer decisions that aren't there.
+- **Duplicating entries**: When appending, check existing content for duplicates
+  before adding.
+- **Over-extraction**: Prefer fewer, high-quality entries over exhaustive lists.
+  Each entry should be actionable or informative.
+
+## Quality Check
+
+- Correct > Complete > Minimal (ACE-FCA)
+- Every entry traces to a specific plan file
+- Decisions include rationale, not just the choice
+- Alternatives include why they were rejected
+- Patterns are genuinely recurring (seen in 2+ plans) or significant

--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/SKILL.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/SKILL.md
@@ -82,6 +82,7 @@ Track per work stream to surface where you are and what shift is needed.
 │   ├── memory/MEMORY.md             # Per-project persistent knowledge
 │   ├── <session-uuid>.jsonl         # Full transcripts (metadata-scan only)
 │   └── <session-uuid>/subagents/    # Subagent transcripts
+├── session-summaries/*.md             # Per-session distilled summaries
 ├── plans/*.md                       # Plan mode files
 ├── tasks/<session-or-team-name>/    # Tasks (*.json, skip .lock/.highwatermark)
 └── teams/<team-name>/               # config.json + inboxes/<member>.json
@@ -122,6 +123,7 @@ respect the filter. Apply these rules once, consistently:
    - **Plans**: `plans/*.md` — goals, open questions, decisions
    - **Tasks**: `tasks/*/*.json` — dependency graph, status
    - **Teams**: `teams/*/config.json` + `inboxes/*.json` — structure, comms
+   - **Session summaries**: `session-summaries/*.md` — distilled session insights (skip if directory absent)
    - **Session metadata**: First+last 5 lines of `.jsonl` — timestamps, branches
    - **Project docs**: Decoded project path → `CHANGELOG.md`, `AGENT_REQUESTS.md`
 
@@ -150,7 +152,7 @@ respect the filter. Apply these rules once, consistently:
 ## Active Work Streams
 ### <Project>
 - **Status:** active/stalled — N sessions in last 7d
-- **Focus:** <from memory + latest sessions>
+- **Focus:** <from memory, session summaries + latest sessions>
 - **Mode:** <diverging+tactical = exploring> | <converging+strategic = building>
 - **Key decisions / Open questions:** <from plans>
 - **Tasks:** N open / N total — blockers: <list>


### PR DESCRIPTION
## Summary

- Bigpicture skill now reads `~/.claude/session-summaries/*.md` as data source (#44)
- New `/distilling-plan-learnings` skill extracts decisions, rejected alternatives, and patterns from plans (#42)
- Bump cc-meta 1.4.0 → 1.5.0

## Changes

### #44: Session-summaries in bigpicture
- Added to CC Data Sources tree
- Added to Workflow "Collect signals" step (with graceful skip if absent)
- Updated output format "Focus" to reference session summaries

### #42: Plan-to-learnings distiller
- New `plugins/cc-meta/skills/distilling-plan-learnings/SKILL.md`
- Follows Pattern D (Meta-Analysis) from bigpicture
- Reads `~/.claude/plans/*.md` filtered by mtime (default 7d)
- Extracts 3 categories: decisions, rejected alternatives, patterns
- Outputs with date headers to configurable path

## Test plan

- [ ] `/synthesizing-cc-bigpicture` runs with/without `~/.claude/session-summaries/`
- [ ] `/distilling-plan-learnings` runs with sample plans in `~/.claude/plans/`
- [ ] `claude plugin validate .` passes

Closes #44
Closes #42

Generated with Claude <noreply@anthropic.com>