### PR TITLE
feat(makefile-core): add Makefile skill with linter and conventions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -154,6 +154,12 @@
       "source": "./plugins/security-audit",
       "description": "Code security audit — OWASP Top 10, dependency vulnerabilities, secrets detection",
       "version": "1.0.0"
+    },
+    {
+      "name": "makefile-core",
+      "source": "./plugins/makefile-core",
+      "description": "Skills and linting for consistent, rigorous Makefiles across projects",
+      "version": "1.0.0"
     }
   ]
 }

--- a/plugins/makefile-core/.claude-plugin/plugin.json
+++ b/plugins/makefile-core/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "makefile-core",
+  "version": "1.0.0",
+  "description": "Skills and linting for consistent, rigorous Makefiles across projects",
+  "author": {
+    "name": "Claude Code Utils Contributors"
+  },
+  "keywords": ["makefile", "make", "build", "automation", "lint"]
+}

--- a/plugins/makefile-core/README.md
+++ b/plugins/makefile-core/README.md
@@ -1,0 +1,22 @@
+# makefile-core
+
+Skills and linting for consistent, rigorous Makefiles across projects.
+
+## Skills
+
+- `creating-makefile` — Scaffold or review Makefiles following org conventions
+
+## References
+
+- `makefile-conventions.md` — Required structure, naming, and patterns
+- `lint-makefile.sh` — Bash linter for CI enforcement
+
+## Usage
+
+```bash
+# In Claude Code
+/creating-makefile my-project
+
+# Standalone lint
+bash plugins/makefile-core/skills/creating-makefile/references/lint-makefile.sh
+```

--- a/plugins/makefile-core/skills/creating-makefile/SKILL.md
+++ b/plugins/makefile-core/skills/creating-makefile/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: creating-makefile
+description: Scaffold or review Makefiles following org conventions. Use when creating a new Makefile, auditing an existing one, or adding recipes to a project.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, Edit, Write, Bash
+  argument-hint: [project-name-or-makefile-path]
+  stability: stable
+---
+
+# Creating Makefiles
+
+**Target**: $ARGUMENTS
+
+Creates or reviews a **rigorous, consistent Makefile** following org conventions.
+
+## Quick Reference
+
+- Required structure + patterns: `references/makefile-conventions.md`
+- CI linter script: `references/lint-makefile.sh`
+
+## Required Structure
+
+Every Makefile must have these elements in order:
+
+```makefile
+# Header comment describing the project
+# Run `make` to see all available recipes.
+
+# GNU Make version guard
+ifeq ($(filter oneshell,$(.FEATURES)),)
+$(error GNU Make >= 3.82 required (.ONESHELL). macOS ships 3.81 — install via: brew install make, then use gmake)
+endif
+
+.SILENT:
+.ONESHELL:
+.PHONY: \
+	recipe_a recipe_b \
+	help
+.DEFAULT_GOAL := help
+
+# -- config --
+VERBOSE ?= 0
+ifeq ($(VERBOSE),0)
+  # quiet flags per tool
+endif
+```
+
+## Conventions
+
+- **snake_case** for all recipe names
+- **`## description`** comment on every public recipe (for help output)
+- **`# MARK: SECTION`** to group related recipes
+- **`setup_*`** prefix for installation recipes (never bare `install`)
+- **`validate`** chains `lint` + `test` (when both exist)
+- **Idempotent setup**: `command -v X >/dev/null || install X`
+- **No hardcoded paths** — use variables at top of file
+- **`VERBOSE ?= 0`** with conditional quiet flags per tool
+
+## Scaffold by Project Type
+
+### Shell/BATS project
+```makefile
+# MARK: SETUP
+setup_dev:  ## Install dev dependencies
+
+# MARK: QUALITY
+test:       ## Run tests (VERBOSE=1 for full output)
+lint:       ## Run shellcheck/actionlint
+validate: lint test  ## Full validation
+
+# MARK: CLEANUP
+clean:      ## Remove artifacts
+
+# MARK: HELP
+help:       ## Show available recipes
+```
+
+### Python (uv) project
+```makefile
+# MARK: SETUP
+setup_dev:  ## Install dev + test dependencies
+
+# MARK: QUALITY
+test:       ## Run pytest
+lint:       ## Ruff format + check
+check_types: ## Pyright
+validate: lint check_types test  ## Full validation
+
+# MARK: HELP
+help:       ## Show available recipes
+```
+
+## Help Recipe (standard pattern)
+
+```makefile
+help:  ## Show available recipes grouped by section
+	@echo "Usage: make [recipe]"
+	@echo ""
+	@awk '/^# MARK:/ { \
+		section = substr($$0, index($$0, ":")+2); \
+		printf "\n\033[1m%s\033[0m\n", section \
+	} \
+	/^[a-zA-Z0-9_-]+:.*?##/ { \
+		helpMessage = match($$0, /## (.*)/); \
+		if (helpMessage) { \
+			recipe = $$1; \
+			sub(/:/, "", recipe); \
+			printf "  \033[36m%-22s\033[0m %s\n", recipe, substr($$0, RSTART + 3, RLENGTH) \
+		} \
+	}' $(MAKEFILE_LIST)
+```
+
+## Workflow
+
+1. **Check** if Makefile exists — create or review
+2. **Lint** with `references/lint-makefile.sh` — fix any failures
+3. **Verify** `make` shows help, `make validate` runs clean
+4. **Commit** Makefile changes
+
+## Quality Gates
+
+- [ ] GNU Make version guard present
+- [ ] `.SILENT`, `.ONESHELL`, `.DEFAULT_GOAL := help` set
+- [ ] Full `.PHONY` list up front
+- [ ] Every recipe has `## description` comment
+- [ ] `# MARK:` sections group related recipes
+- [ ] `snake_case` recipe names only
+- [ ] `help` recipe with standard awk pattern
+- [ ] `VERBOSE ?= 0` with quiet mode support
+- [ ] `lint-makefile.sh` passes

--- a/plugins/makefile-core/skills/creating-makefile/references/lint-makefile.sh
+++ b/plugins/makefile-core/skills/creating-makefile/references/lint-makefile.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# lint-makefile.sh — Lint a Makefile for org conventions.
+# Usage: lint-makefile.sh [path/to/Makefile]
+# Exit 0 = pass, 1 = failures found.
+
+set -uo pipefail
+
+MAKEFILE="${1:-Makefile}"
+ERRORS=0
+
+fail() {
+  echo "FAIL: $1"
+  ERRORS=$((ERRORS + 1))
+}
+
+if [[ ! -f "$MAKEFILE" ]]; then
+  echo "ERROR: $MAKEFILE not found"
+  exit 1
+fi
+
+# --- Required directives ---
+
+grep -q '\.ONESHELL' "$MAKEFILE" \
+  || fail ".ONESHELL not found"
+
+grep -q '\.SILENT' "$MAKEFILE" \
+  || fail ".SILENT not found"
+
+grep -q '\.DEFAULT_GOAL' "$MAKEFILE" \
+  || fail ".DEFAULT_GOAL not set"
+
+grep -q '\.PHONY' "$MAKEFILE" \
+  || fail ".PHONY declaration not found"
+
+# --- Version guard ---
+
+grep -q 'oneshell.*\.FEATURES\|\.FEATURES.*oneshell' "$MAKEFILE" \
+  || fail "GNU Make version guard (.FEATURES/oneshell check) not found"
+
+# --- Sections ---
+
+grep -q '^# MARK:' "$MAKEFILE" \
+  || fail "No # MARK: sections found"
+
+# --- Help recipe ---
+
+grep -qE '^help:|^show_help:' "$MAKEFILE" \
+  || fail "No help recipe found"
+
+# --- Recipe documentation ---
+
+# Count recipes (lines matching "name: ...") vs documented recipes ("name: ... ##")
+TOTAL_RECIPES=$(grep -E '^[a-zA-Z0-9_-]+:' "$MAKEFILE" 2>/dev/null | wc -l)
+DOCUMENTED=$(grep -E '^[a-zA-Z0-9_-]+:.*##' "$MAKEFILE" 2>/dev/null | wc -l)
+
+if [[ "$TOTAL_RECIPES" -gt 0 && "$DOCUMENTED" -lt "$TOTAL_RECIPES" ]]; then
+  UNDOCUMENTED=$((TOTAL_RECIPES - DOCUMENTED))
+  fail "$UNDOCUMENTED recipe(s) missing ## description comment"
+fi
+
+# --- Naming ---
+
+BAD_NAMES=$(grep -oE '^[a-zA-Z0-9_-]+:' "$MAKEFILE" | sed 's/://' | grep -E '[A-Z]' | grep -v '^[A-Z_]*$' || true)
+if [[ -n "$BAD_NAMES" ]]; then
+  fail "Non-snake_case recipe names: $BAD_NAMES"
+fi
+
+# --- Results ---
+
+if [[ "$ERRORS" -eq 0 ]]; then
+  echo "OK: $MAKEFILE passes all checks"
+  exit 0
+else
+  echo ""
+  echo "$ERRORS check(s) failed"
+  exit 1
+fi

--- a/plugins/makefile-core/skills/creating-makefile/references/makefile-conventions.md
+++ b/plugins/makefile-core/skills/creating-makefile/references/makefile-conventions.md
@@ -1,0 +1,62 @@
+# Makefile Conventions
+
+## Required Elements (checked by lint-makefile.sh)
+
+| Element | Why |
+|---------|-----|
+| `.ONESHELL` | Multi-line recipes run in one shell — no `&&` chains needed |
+| `.SILENT` | Suppress recipe echo — cleaner output |
+| `.DEFAULT_GOAL := help` | `make` without args shows help |
+| `.PHONY` block | Declare all targets — prevent file-name collisions |
+| `# MARK:` sections | Group recipes — parsed by help recipe |
+| `## comment` on recipes | Self-documenting — parsed by help recipe |
+| `help` recipe | Standard awk pattern for grouped, colored output |
+| Version guard | Catch GNU Make < 3.82 (macOS default) |
+
+## Naming
+
+- `snake_case` for recipes: `setup_dev`, `run_tests`, `check_types`
+- `UPPER_CASE` for variables: `VERBOSE`, `OUTPUT_DIR`, `SRC_PATH`
+- `setup_*` for installation (never bare `install` — conflicts with system `install`)
+- `clean_*` for cleanup variants (`clean_logs`, `clean_results`)
+
+## Patterns
+
+### Idempotent setup
+```makefile
+setup_dev:
+	command -v bats >/dev/null || npm install -g bats
+	command -v shellcheck >/dev/null || sudo apt-get install -y shellcheck
+```
+
+### Quiet mode
+```makefile
+VERBOSE ?= 0
+ifeq ($(VERBOSE),0)
+  PYTEST_QUIET := -q --tb=short --no-header
+  RUFF_QUIET := --quiet
+  BATS_FILTER := | grep -v '^ok '
+endif
+```
+
+### Validation chain
+```makefile
+validate: lint test  ## Full validation (lint + test)
+quick_validate: lint check_types  ## Fast validation (no tests)
+```
+
+### Conditional dependencies
+```makefile
+setup_all: setup_dev setup_cad setup_slicer  ## Install all
+```
+
+## Anti-Patterns
+
+| Don't | Do |
+|-------|-----|
+| `install:` | `setup_dev:` |
+| Hardcoded paths in recipes | Variables at top |
+| `@` prefix per line | `.SILENT` globally |
+| Missing `.PHONY` | Full list up front |
+| No `help` recipe | Standard awk pattern |
+| `echo` for status | Rely on `.SILENT` + explicit echo only when needed |


### PR DESCRIPTION
## Summary
New `makefile-core` plugin enforcing consistent Makefile rigor:

- `creating-makefile` skill — scaffold, conventions, quality gates
- `lint-makefile.sh` — 9 structural checks, CI-ready (exit 0/1)
- `makefile-conventions.md` — required elements, naming, patterns, anti-patterns

### Linter checks
1. `.ONESHELL` present
2. `.SILENT` present
3. `.DEFAULT_GOAL` set
4. `.PHONY` declaration
5. GNU Make version guard
6. `# MARK:` sections
7. `help` recipe
8. `##` description on every recipe
9. `snake_case` recipe names

### Tested against
- [x] gha-cross-repo-issue-sync Makefile — passes
- [x] so101-biolab-automation Makefile — passes
- [x] Intentionally bad Makefile — catches all 9 violations

Generated with Claude <noreply@anthropic.com>