### PR TITLE
chore(marketplace): sync cc-voice version to 0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -122,8 +122,8 @@
         "source": "github",
         "repo": "qte77/cc-voice-plugin-prototype"
       },
-      "description": "E2E voice \u2014 TTS via PTY proxy (/speak), STT via Moonshine (/listen, planned).",
-      "version": "0.3.0"
+      "description": "E2E voice \u2014 TTS via PTY proxy (/speak), STT via Moonshine (/listen, functional).",
+      "version": "0.4.0"
     },
     {
       "name": "typescript-dev",


### PR DESCRIPTION
## Summary
- Update cc-voice version 0.3.0 → 0.4.0 in marketplace.json
- Update description to reflect functional /listen

## Test plan
- [ ] marketplace.json valid JSON
- [ ] cc-voice version reads "0.4.0"

Closes #16

Generated with Claude <noreply@anthropic.com>