### PR TITLE
feat(cc-meta): add lightweight session handoff skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,7 +36,7 @@
       "name": "cc-meta",
       "source": "./plugins/cc-meta",
       "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
-      "version": "1.10.0"
+      "version": "1.11.0"
     },
     {
       "name": "backend-design",

--- a/plugins/cc-meta/.claude-plugin/plugin.json
+++ b/plugins/cc-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-meta",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
   "author": {
     "name": "Claude Code Utils Contributors"

--- a/plugins/cc-meta/README.md
+++ b/plugins/cc-meta/README.md
@@ -8,6 +8,7 @@ Claude Code meta-skills for cross-project synthesis and session intelligence.
 - **distilling-plan-learnings** — Extracts decisions, rejected alternatives, and patterns from recent plans into a persistent learnings document. Use after completing a plan or sprint.
 - **compacting-context** — Distills verbose outputs into structured summaries following ACE-FCA principles. Use after pollution sources (searches, logs, JSON) or at phase milestones.
 - **summarizing-session-end** — Auto-generates a session summary on SessionEnd hook. Writes structured notes to `~/.claude/session-summaries/` for bigpicture synthesis.
+- **handing-off-session** — Generates structured session handoff notes for cross-session continuity. Stateless markdown files in `.claude/handoffs/`.
 
 ## Usage
 

--- a/plugins/cc-meta/skills/handing-off-session/SKILL.md
+++ b/plugins/cc-meta/skills/handing-off-session/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: handing-off-session
+description: Generate structured session handoff notes for cross-session continuity. Use at end of session or when switching context.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Write, Glob, Grep
+  argument-hint: [output-path]
+  context: inline
+  stability: development
+---
+
+# Session Handoff
+
+**Target**: $ARGUMENTS
+
+Captures session state as a structured markdown note for the next session to
+pick up. Stateless — markdown files only, no database, no daemon.
+
+## Arguments
+
+| Position | Name | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| 1 | `output-path` | no | auto | Where to write the handoff note. |
+
+**Default output path:** `.claude/handoffs/YYYY-MM-DD-<short-description>.md`
+
+The `<short-description>` is a 2-4 word slug derived from the session's primary
+focus (e.g. `2026-04-06-session-handoff-skill.md`).
+
+## When to Use
+
+- End of a work session
+- Switching context to a different project or task
+- Before a long break
+- When context window is getting full and you want to preserve state
+
+## Workflow
+
+1. **Scan conversation** — Identify completed actions, decisions, and pending work
+   from the current session context.
+
+2. **Check git state** — Run `git diff --stat` and `git log --oneline -10` to
+   capture recent changes and commits.
+
+3. **Extract signals** — Collect decisions made, alternatives rejected, blockers
+   encountered, and open questions.
+
+4. **Ensure output dir** — Create `.claude/handoffs/` if it doesn't exist.
+
+5. **Write handoff note** — Use the template below. Be concise — enough to
+   resume, no more.
+
+## Output Template
+
+```markdown
+# Session Handoff — <date>
+
+## What Was Done
+[Completed work, key commits, PRs created/merged]
+
+## What's Pending
+[Open tasks, unfinished work, next steps]
+
+## Key Decisions
+[Architectural choices, trade-offs made, rejected alternatives]
+
+## Modified Files
+[List of files changed with brief reason]
+
+## Blockers
+[External dependencies, open questions, things that need user input]
+```
+
+## Picking Up a Handoff
+
+Next session can read the latest handoff:
+
+```bash
+# Find latest handoff
+ls -t .claude/handoffs/*.md | head -1
+```
+
+Or read all recent handoffs to rebuild context across multiple sessions.
+
+## Quality Check
+
+- Correct > Complete > Minimal (ACE-FCA)
+- ~20-50 lines output per handoff
+- Every item traces to a concrete action or artifact
+- No raw dumps — structured summaries only


### PR DESCRIPTION
## Summary
- New `handing-off-session` skill in cc-meta
- Structured handoff notes: done, pending, decisions, files, blockers
- Stateless markdown files in `.claude/handoffs/`
- Pickup via glob + sort for next session

## Test plan
- [ ] SKILL.md frontmatter valid
- [ ] Template sections cover essential handoff info
- [ ] Output path convention documented

Closes #76

Generated with Claude <noreply@anthropic.com>