### PR TITLE
feat(workspace): register qte77 marketplace in base settings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,13 +72,13 @@
       "name": "workspace-setup",
       "source": "./plugins/workspace-setup",
       "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
-      "version": "1.3.3"
+      "version": "1.3.4"
     },
     {
       "name": "workspace-sandbox",
       "source": "./plugins/workspace-sandbox",
       "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
-      "version": "1.3.3"
+      "version": "1.3.4"
     },
     {
       "name": "docs-governance",

--- a/plugins/workspace-sandbox/.claude-plugin/plugin.json
+++ b/plugins/workspace-sandbox/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-sandbox",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "sandbox", "read-once"]

--- a/plugins/workspace-sandbox/settings/settings-sandbox.json
+++ b/plugins/workspace-sandbox/settings/settings-sandbox.json
@@ -14,6 +14,14 @@
   "enabledPlugins": {
     "context7@claude-plugins-official": true
   },
+  "extraKnownMarketplaces": {
+    "qte77-claude-code-utils": {
+      "source": {
+        "source": "github",
+        "repo": "qte77/claude-code-utils-plugin"
+      }
+    }
+  },
   "attribution": {
     "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
     "pr": "Generated with Claude <noreply@anthropic.com>"

--- a/plugins/workspace-setup/.claude-plugin/plugin.json
+++ b/plugins/workspace-setup/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-setup",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "governance", "setup", "read-once"]

--- a/plugins/workspace-setup/settings/settings-base.json
+++ b/plugins/workspace-setup/settings/settings-base.json
@@ -14,6 +14,14 @@
   "enabledPlugins": {
     "context7@claude-plugins-official": true
   },
+  "extraKnownMarketplaces": {
+    "qte77-claude-code-utils": {
+      "source": {
+        "source": "github",
+        "repo": "qte77/claude-code-utils-plugin"
+      }
+    }
+  },
   "permissions": {
     "allow": [
       "AskUserQuestion",


### PR DESCRIPTION
## Summary
- Add `extraKnownMarketplaces` entry for `qte77-claude-code-utils` to both workspace-setup and workspace-sandbox settings
- Without this, deployed workspaces cannot discover or update plugins from the qte77 marketplace
- Bump workspace-setup and workspace-sandbox 1.3.3 → 1.3.4

## Test plan
- [ ] Verify `settings-base.json` contains `extraKnownMarketplaces` with github source
- [ ] Verify `settings-sandbox.json` contains matching entry
- [ ] Verify plugin.json and marketplace.json versions match at 1.3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)