### PR TITLE
feat(cc-meta): persist bigpicture synthesis to learnings hub

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,7 +36,7 @@
       "name": "cc-meta",
       "source": "./plugins/cc-meta",
       "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
-      "version": "1.11.0"
+      "version": "1.12.0"
     },
     {
       "name": "backend-design",

--- a/plugins/cc-meta/.claude-plugin/plugin.json
+++ b/plugins/cc-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-meta",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
   "author": {
     "name": "Claude Code Utils Contributors"

--- a/plugins/cc-meta/README.md
+++ b/plugins/cc-meta/README.md
@@ -9,6 +9,7 @@ Claude Code meta-skills for cross-project synthesis and session intelligence.
 - **compacting-context** — Distills verbose outputs into structured summaries following ACE-FCA principles. Use after pollution sources (searches, logs, JSON) or at phase milestones.
 - **summarizing-session-end** — Auto-generates a session summary on SessionEnd hook. Writes structured notes to `~/.claude/session-summaries/` for bigpicture synthesis.
 - **handing-off-session** — Generates structured session handoff notes for cross-session continuity. Stateless markdown files in `.claude/handoffs/`.
+- **persisting-bigpicture-learnings** — Persists bigpicture synthesis as dated snapshots in a learnings hub. Maintains latest pointer + append-only archive for cross-session compound learning.
 
 ## Usage
 

--- a/plugins/cc-meta/skills/persisting-bigpicture-learnings/SKILL.md
+++ b/plugins/cc-meta/skills/persisting-bigpicture-learnings/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: persisting-bigpicture-learnings
+description: Persist bigpicture synthesis as dated snapshots in a learnings hub. Maintains latest pointer + append-only archive for cross-session compound learning.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Write, Glob
+  argument-hint: [input-path] [hub-path]
+  context: inline
+  stability: development
+---
+
+# Persist Bigpicture to Learnings Hub
+
+**Target**: $ARGUMENTS
+
+Persists the output of `/synthesizing-cc-bigpicture` as a dated snapshot in a
+learnings hub. Maintains a `latest.md` pointer (always current) and an
+append-only archive for compound cross-session learning.
+
+## Arguments
+
+| Position | Name | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| 1 | `input-path` | no | `bigpicture.md` | Path to bigpicture synthesis output |
+| 2 | `hub-path` | no | `docs/learnings/cc-bigpicture/` | Directory for learnings hub |
+
+**Examples:**
+
+```
+/persisting-bigpicture-learnings
+/persisting-bigpicture-learnings ~/.claude/bigpicture.md
+/persisting-bigpicture-learnings bigpicture.md docs/learnings/cc-bigpicture/
+```
+
+## Output Structure
+
+```
+docs/learnings/cc-bigpicture/
+├── latest.md          # Always the most recent synthesis
+└── archive/
+    ├── 2026-04-01.md
+    ├── 2026-04-03.md
+    └── 2026-04-06.md  # Today's snapshot
+```
+
+## Workflow
+
+1. **Parse arguments** — Apply defaults per Arguments table.
+
+2. **Read input** — Read `input-path`. If the file does not exist, report error
+   and stop.
+
+3. **Create hub directory** — Create `hub-path` and `hub-path/archive/` if
+   absent.
+
+4. **Write latest** — Write full synthesis content to `hub-path/latest.md`.
+   Always overwrite — this is the current-state pointer.
+
+5. **Write archive snapshot** — Determine today's date (`YYYY-MM-DD`).
+   - If `hub-path/archive/YYYY-MM-DD.md` does **not** exist, create it with
+     the synthesis content.
+   - If it **does** exist, append a `---` separator followed by the new
+     synthesis content. This preserves all snapshots from the same day.
+
+6. **Report** — Confirm paths written and archive entry count for today.
+
+## Integration
+
+Runs after `/synthesizing-cc-bigpicture`. Chain the two skills:
+
+```
+/synthesizing-cc-bigpicture all 7d bigpicture.md
+/persisting-bigpicture-learnings bigpicture.md docs/learnings/cc-bigpicture/
+```
+
+## Compound Learning
+
+Other skills can read `hub-path/latest.md` for prior synthesis context:
+
+- **synthesizing-cc-bigpicture** — Load previous synthesis for incremental
+  update instead of cold start.
+- **ralph / PRD skills** — Reference latest bigpicture for strategic context.
+- **compacting-context** — Include bigpicture summary when compacting at phase
+  boundaries.
+
+## Quality Check
+
+- `latest.md` content matches the most recent archive entry
+- Archive files are append-only — never overwrite, never delete
+- Hub path directories created automatically
+- Input file validated before any writes


### PR DESCRIPTION
## Summary
- New `persisting-bigpicture-learnings` skill
- Writes `latest.md` (overwrite) + `archive/YYYY-MM-DD.md` (append-only)
- Chains after `/synthesizing-cc-bigpicture` for compound learning

## Test plan
- [ ] SKILL.md frontmatter valid
- [ ] latest.md is overwrite, archive is append-only
- [ ] Hub path structure documented

Closes #86

Generated with Claude <noreply@anthropic.com>