### PR TITLE
feat(cc-meta): progressive retrieval for bigpicture synthesis

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
       "name": "cc-meta",
       "source": "./plugins/cc-meta",
       "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
-      "version": "1.4.0"
+      "version": "1.8.0"
     },
     {
       "name": "backend-design",

--- a/plugins/cc-meta/.claude-plugin/plugin.json
+++ b/plugins/cc-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-meta",
-  "version": "1.4.0",
+  "version": "1.8.0",
   "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["meta", "big-picture", "synthesis", "context", "compaction", "sessions", "plans", "reasoning-modes"]

--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/SKILL.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/SKILL.md
@@ -115,7 +115,13 @@ respect the filter. Apply these rules once, consistently:
 3. **Discover & filter projects** — Glob `~/.claude/projects/*/`. Decode paths.
    Apply project filter if set. Build session allowlist from `history.jsonl`.
 
-4. **Collect signals** (sequential, metadata-first, no subagents):
+4. **Progressive retrieval** — Escalate through tiers, stop when every output
+   section has concrete evidence. See `references/progressive-retrieval.md`
+   for tier definitions, cost estimates, and the escalation rule. Start at
+   Tier 1 (metadata-only).
+
+5. **Collect signals** — Following the progressive retrieval tiers, collect
+   signals starting from Tier 1 (sequential, metadata-first, no subagents):
    - **Activity**: `stats-cache.json` — daily counts for trajectory
    - **Sessions**: `history.jsonl` — unique sessionIds, timestamps, topics
    - **Memory**: `projects/*/memory/MEMORY.md` — persistent knowledge
@@ -128,15 +134,15 @@ respect the filter. Apply these rules once, consistently:
    **Critical**: Never bulk-read full `.jsonl` transcripts. Use `history.jsonl`
    for discovery and first+last lines for metadata only.
 
-5. **Classify reasoning modes** per work stream:
+6. **Classify reasoning modes** per work stream:
    - Open questions vs. closed decisions → diverge/converge
    - Plan-driven tasks vs. learning entries → strategic/tactical
    - Flag imbalances (see alerts above)
 
-6. **Synthesize** — Group by project → time clusters. Link plans↔sessions↔tasks.
+7. **Synthesize** — Group by project → time clusters. Link plans↔sessions↔tasks.
    Surface blockers, trajectory, recurring themes, cross-project connections.
 
-7. **Output** using format below. Write to output path.
+8. **Output** using format below. Write to output path.
 
 ## Output Format
 

--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/progressive-retrieval.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/progressive-retrieval.md
@@ -1,0 +1,43 @@
+# Progressive Retrieval Tiers
+
+Escalate through tiers — stop as soon as the current tier's data answers every
+output template section with concrete evidence (not guesses). Otherwise escalate
+to the next tier.
+
+## Tier 1 — Fast metadata (always, <5s)
+
+- `stats-cache.json`: token counts, session durations, tool usage
+- `history.jsonl`: recent command history (last 50 entries)
+- `.claude/memory/MEMORY.md`: memory index
+- **Cost**: ~500 tokens
+- **Sufficient for**: activity summaries, tool usage stats
+
+## Tier 2 — Structured summaries (if Tier 1 insufficient)
+
+- `session-summaries/*.md`: distilled session notes
+- `plans/*.md`: active/recent plans (filter by mtime)
+- `AGENT_LEARNINGS.md`, `AGENTS.md`: governance state
+- **Cost**: ~2-5K tokens
+- **Sufficient for**: focus areas, trajectory, active work streams
+
+## Tier 3 — Targeted deep reads (if Tier 2 insufficient)
+
+- Session JSONL: first 5 + last 5 lines per file (max 10 files by mtime)
+- Subagent transcripts: first 5 + last 5 lines (max 10 files)
+- Git log: recent commits for changed-file context
+- **Cost**: ~5-15K tokens
+- **Sufficient for**: detailed synthesis, cross-project patterns
+
+## Tier 4 — Full scan (never in normal flow)
+
+- Complete JSONL transcript reads
+- Only if explicitly requested by user with `--deep` flag
+- **Cost**: unbounded — guard with context budget check
+
+## Escalation Rule
+
+After collecting a tier's data, check the output template (Reasoning Mode Summary,
+Active Work Streams, Cross-Project Connections, Active Plans, TODOs & DONEs,
+Blockers & Stale Items, Mode Transitions Needed). If every section can be filled
+with concrete evidence from the current tier, stop. Otherwise escalate to the
+next tier.


### PR DESCRIPTION
## Summary
- 4-tier progressive retrieval: metadata → summaries → deep reads → full scan
- Escalation rule: stop when all output sections have concrete evidence
- Token cost ranges per tier documented
- Bump cc-meta to 1.8.0

## Test plan
- [ ] Tiers are clearly defined with cost estimates
- [ ] Escalation rule is unambiguous
- [ ] Existing workflow steps preserved, wrapped in tier references
- [ ] plugin.json and marketplace.json both show 1.8.0
- [ ] SKILL.md body stays tight — tier definitions live in `references/progressive-retrieval.md`

## Update per review (2026-04-11)

Tier protocol extracted into `plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/progressive-retrieval.md` to avoid SKILL.md growth. SKILL.md body now reads the tier definitions on demand via a 4-line workflow reference step, preserving the ~25k-token shared skill auto-compaction budget. SKILL.md net change: **+5 / -30 lines** (down from the original +35 / -4). Final SKILL.md: 188 lines (vs. 214 pre-refactor, 183 pre-PR). Context rationale tracked in #103. See also [review comment](https://github.com/qte77/claude-code-utils-plugin/pull/99#issuecomment-4229654305).

Closes #65

Generated with Claude <noreply@anthropic.com>