### PR TITLE
feat(codebase-tools): add hardening-codebase skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,8 +23,8 @@
     {
       "name": "codebase-tools",
       "source": "./plugins/codebase-tools",
-      "description": "Isolated codebase research and exploration via subagent",
-      "version": "1.1.0"
+      "description": "Isolated codebase research, exploration, and quality hardening via subagent",
+      "version": "1.2.0"
     },
     {
       "name": "cc-meta",

--- a/plugins/codebase-tools/.claude-plugin/plugin.json
+++ b/plugins/codebase-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codebase-tools",
-  "version": "1.1.0",
-  "description": "Isolated codebase research and exploration via subagent",
+  "version": "1.2.0",
+  "description": "Isolated codebase research, exploration, and quality hardening via subagent",
   "author": { "name": "Claude Code Utils Contributors" },
-  "keywords": ["research", "codebase", "exploration"]
+  "keywords": ["research", "codebase", "exploration", "hardening", "lint", "review"]
 }

--- a/plugins/codebase-tools/skills/hardening-codebase/SKILL.md
+++ b/plugins/codebase-tools/skills/hardening-codebase/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: hardening-codebase
+description: Audit and tighten codebase quality gates — lint, types, tests, code
+  review. Use when onboarding a project, before a release, or when validation is
+  too permissive.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob, Bash, Edit, Write, Agent
+  argument-hint: "[scope: full | audit | tighten | review | fix]"
+  stability: experimental
+---
+
+# Harden Codebase
+
+**Scope**: $ARGUMENTS (default: full)
+
+Systematic quality tightening. Seven phases, each with a clear gate.
+KISS: tighten one level at a time — never jump to max strictness.
+
+## Phase 1: AUDIT (read-only)
+
+1. Does `make setup_all` (or equivalent) work from scratch?
+2. What lint rules are enabled? Gap vs recommended?
+   See `references/lint-tightening-checklist.md`
+3. Type checker strictness level?
+4. Do tests pass? Are slow/hardware tests filtered?
+5. Is check-only gate separate from auto-fix?
+
+**Gate**: Issue list ranked HIGH/MEDIUM/LOW. Present to user before
+proceeding.
+
+## Phase 2: TIGHTEN (config only — no code changes)
+
+1. Enable next-level lint rules (baseline → recommended, not strict)
+2. Bump type checker one level
+3. Split auto-fix from check-only gate if missing
+4. Add test marker filters for slow/hardware/network
+5. Count new violations — report before fixing
+
+**Gate**: Config committed. Violation count known.
+
+## Phase 3: FIX (mechanical)
+
+1. Run auto-fix
+2. Fix remaining violations manually
+3. Update tests broken by signature changes
+4. `make validate` must pass
+
+**Gate**: All checks green. Commit fixes.
+
+## Phase 4: TEST OVERHAUL (meaningful tests only)
+
+1. Classify every test: behavioral / implementation / trivial
+2. Rewrite implementation tests as behavioral (assert outcomes, not internals)
+3. Delete trivial tests that add no value
+4. Add missing behavioral tests for error recovery, state transitions, edge cases
+5. Add property-based tests (Hypothesis) for invariants
+6. Add complexity gate (complexipy, max 15/function)
+7. `make validate` must pass with coverage gate
+
+**Gate**: All tests behavioral. Coverage ≥ 80%. Complexity ≤ 15.
+
+## Phase 5: REVIEW (3 parallel agents)
+
+Launch all three from `references/review-agents.md`:
+
+- **Reuse**: duplication, missing shared helpers
+- **Quality**: copy-paste, magic strings, abstractions, bugs
+- **Efficiency**: unnecessary work, missed caching
+
+**Gate**: Ranked findings presented to user.
+
+## Phase 6: REFACTOR (apply findings)
+
+1. Fix HIGH and MEDIUM only (80/20)
+2. Skip LOW unless trivial
+3. `make validate` after each fix
+4. Commit by topic
+
+**Gate**: All checks green. Findings addressed.
+
+## Phase 7: SHIP
+
+1. Push branch
+2. Create PR with summary + test plan
+
+## Scope shortcuts
+
+- `audit` — Phase 1 only (read-only report)
+- `tighten` — Phases 1-3 (config + fix)
+- `tests` — Phase 4 only (test overhaul)
+- `review` — Phase 5 only (3-agent review)
+- `fix` — Phase 6 only (apply existing findings)
+- `full` — All phases
+
+## References
+
+See `references/lint-tightening-checklist.md` for language-specific
+rule progressions and `references/review-agents.md` for agent prompts.

--- a/plugins/codebase-tools/skills/hardening-codebase/references/lint-tightening-checklist.md
+++ b/plugins/codebase-tools/skills/hardening-codebase/references/lint-tightening-checklist.md
@@ -1,0 +1,85 @@
+# Lint & Type Tightening Checklist
+
+Tighten one level at a time. Fix violations before tightening further.
+
+## Lint Rules
+
+| Language | Tool | Baseline | Recommended | Strict |
+|----------|------|----------|-------------|--------|
+| Python | ruff | E, F, I | +B, S, SIM, RUF | +C90, ANN, PT |
+| Rust | clippy | default | `clippy::pedantic` | `clippy::restriction` (selective) |
+| C/C++ | clang-tidy | core | +`bugprone-*`, `cppcoreguidelines-*`, `modernize-*` | +`cert-*`, `hicpp-*` |
+| C/C++ | cppcheck | default | `--enable=warning,style` | `--enable=all` |
+| C# | dotnet analyzers | default | `CA*` (all categories) | `TreatWarningsAsErrors` |
+| C# | StyleCop | — | `SA*` rules | — |
+| Go | golangci-lint | default | +errcheck, govet, staticcheck | +exhaustive, gocritic |
+| TypeScript | eslint | recommended | +strict | +strict-type-checked |
+
+## Type Checking
+
+| Language | Tool | Baseline | Recommended | Strict |
+|----------|------|----------|-------------|--------|
+| Python | pyright | basic | standard | strict |
+| Rust | rustc | default (already strict) | `#![deny(warnings)]` | `#![forbid(unsafe_code)]` |
+| C/C++ | compiler flags | `-Wall` | `-Wall -Wextra` | `-Wall -Wextra -Werror -pedantic` |
+| C# | `<Nullable>` | disable | enable | enable + `TreatWarningsAsErrors` |
+| Go | go vet | default | +staticcheck | +nilaway |
+| TypeScript | tsconfig | default | `strict: true` | +`noUncheckedIndexedAccess` |
+
+## Formatting
+
+| Language | Tool | Notes |
+|----------|------|-------|
+| Python | ruff format | `--check` for gate, no flag for fix |
+| Rust | rustfmt | `--check` for gate |
+| C/C++ | clang-format | `--dry-run -Werror` for gate |
+| C# | dotnet format | `--verify-no-changes` for gate |
+| Go | gofmt | `-l` for gate (lists unformatted) |
+| TypeScript | prettier | `--check` for gate |
+
+## Test Frameworks
+
+| Language | Runner | Coverage | Property-based |
+|----------|--------|----------|----------------|
+| Python | pytest | coverage.py | Hypothesis |
+| Rust | cargo test | cargo-tarpaulin | proptest |
+| C/C++ | CTest / GoogleTest | gcov / lcov | — |
+| C# | xUnit / NUnit | coverlet | FsCheck |
+| Go | go test | go tool cover | rapid |
+| TypeScript | vitest / jest | v8 / istanbul | fast-check |
+
+## Per-file Ignores (common, justified)
+
+| Rule | Where | Why |
+|------|-------|-----|
+| `assert` (S101) | test files | pytest requires assert |
+| `subprocess` (S603) | trusted internal scripts | not user input |
+| line length | generated files, test data | readability tradeoff |
+
+## Cognitive Complexity
+
+| Language | Tool | Gate threshold | Notes |
+|----------|------|---------------|-------|
+| Python | complexipy | 15/function | `complexipy app/ --max-complexity 15` |
+| Rust | clippy `cognitive_complexity` | 25 (default) | built into clippy |
+| C/C++ | clang-tidy `readability-function-cognitive-complexity` | 25 | configurable |
+| TypeScript | eslint `complexity` | 20 | cyclomatic, not cognitive |
+
+## Snapshot Testing
+
+| Language | Tool | Purpose |
+|----------|------|---------|
+| Python | inline-snapshot | Regression contracts for API shapes, config defaults |
+| Rust | insta | Snapshot testing for serialized output |
+| TypeScript | vitest inline snapshots | `expect(x).toMatchInlineSnapshot()` |
+
+## Gate vs Fix Split
+
+Every project needs two recipes:
+
+```
+autofix    — format + lint --fix (developer convenience)
+lint       — format --check + lint (CI gate, fails on issues)
+complexity — cognitive complexity check (gate, fails above threshold)
+validate   — lint + types + tests + coverage (full gate, must pass before commit)
+```

--- a/plugins/codebase-tools/skills/hardening-codebase/references/review-agents.md
+++ b/plugins/codebase-tools/skills/hardening-codebase/references/review-agents.md
@@ -1,0 +1,63 @@
+# Review Agent Prompts
+
+Launch all three in parallel via the Agent tool. Pass the diff or file
+list as context to each.
+
+## Agent 1: Code Reuse
+
+```
+Review changed files for CODE REUSE issues.
+
+For each change:
+1. Search for existing utilities/helpers that could replace new code
+2. Flag duplicate functionality across files
+3. Flag inline logic that could use shared utilities
+
+Focus on: repeated patterns, copy-pasted functions with slight
+variation, fragile path computations that should be centralized.
+
+Report: file, issue, suggested fix. No false positives.
+```
+
+## Agent 2: Code Quality
+
+```
+Review changed files for CODE QUALITY issues.
+
+Look for:
+1. Redundant state — duplicates existing state, could be derived
+2. Parameter sprawl — adding params instead of restructuring
+3. Copy-paste with variation — near-duplicate blocks to unify
+4. Leaky abstractions — exposing internals, breaking boundaries
+5. Stringly-typed code — raw strings where constants/enums exist
+6. Logic bugs — off-by-one, unguarded None, silent fallthrough
+
+Report: file, issue, suggested fix. Skip false positives.
+```
+
+## Agent 3: Efficiency
+
+```
+Review changed files for EFFICIENCY issues.
+
+Look for:
+1. Unnecessary work — redundant computations, repeated reads
+2. Missed caching — same expensive result computed multiple times
+3. Missed concurrency — independent ops run sequentially
+4. N+1 patterns — loop of individual calls instead of batch
+5. Overly broad operations — reading all when filtering for one
+6. TOCTOU — pre-checking existence before operating
+
+Report: file, issue, estimated savings. Skip false positives.
+```
+
+## Aggregation
+
+After all three complete, deduplicate findings (agents often flag the
+same issue from different angles). Rank by severity:
+
+- **HIGH**: bugs, security, >50 lines of duplication
+- **MEDIUM**: caching, DRY violations, magic strings
+- **LOW**: minor inefficiency, style preferences
+
+Present to user before fixing. Fix HIGHs and MEDIUMs only.


### PR DESCRIPTION
## Summary

- New `hardening-codebase` skill with 7-phase workflow: audit → tighten → fix → test overhaul → review → refactor → ship
- Language-agnostic SKILL.md with scope shortcuts (audit, tighten, tests, review, fix, full)
- `references/lint-tightening-checklist.md` covering Python, Rust, C/C++, C#, Go, TypeScript
- `references/review-agents.md` with 3 parallel agent prompts (reuse, quality, efficiency)
- Cognitive complexity gates (complexipy, clippy, clang-tidy)
- Snapshot testing references (inline-snapshot, insta)
- Plugin version bump 1.1.0 → 1.2.0

## Test plan

- [x] SKILL.md follows existing skill format (frontmatter, workflow, references)
- [x] References use markdown tables consistent with other skills
- [x] Plugin version matches in both plugin.json and marketplace.json
- [ ] Install plugin and verify `/hardening-codebase audit` loads correctly

Generated with Claude <noreply@anthropic.com>