### PR TITLE
refactor(mas-design): extract reference material from both skill bodies (#103)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
       "name": "mas-design",
       "source": "./plugins/mas-design",
       "description": "Multi-agent system plugin design and OWASP MAESTRO security framework",
-      "version": "1.0.1"
+      "version": "1.1.0"
     },
     {
       "name": "website-audit",

--- a/plugins/mas-design/.claude-plugin/plugin.json
+++ b/plugins/mas-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mas-design",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "MAS plugin design and multi-framework security auditing (OWASP MAESTRO, MITRE ATLAS, NIST AI RMF, ISO 42001/23894)",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["mas", "multi-agent", "plugin", "security", "maestro", "owasp", "mitre", "atlas", "nist", "iso", "pydantic"]

--- a/plugins/mas-design/skills/designing-mas-plugins/SKILL.md
+++ b/plugins/mas-design/skills/designing-mas-plugins/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   allowed-tools: Read, Grep, Glob, WebSearch, WebFetch
   argument-hint: [component-name]
   stability: stable
-  content-hash: sha256:e622a74b96cffd4da81194994178e60b0dadf70fb28d46587f581bba07bc3fec
+  content-hash: sha256:44f931b696bbfe8ea3acf1d6d3e979d90b86144040f596acd7bf9e865f228627
   last-verified-cc-version: 1.0.34
 ---
 
@@ -23,73 +23,17 @@ Trigger this skill when:
 - Architecting new metrics or evaluation tiers
 - Refactoring engines into plugin patterns
 
-## References
-
-**MUST READ**:
-`references/mas-design-principles.md`
-
 ## Core Principles
 
-### Stateless Reducer Pattern
+Plugins follow six principles. For worked code examples of each, see
+`references/core-principles-with-examples.md`.
 
-Each plugin is a pure function:
-`evaluate(context: BaseModel) -> BaseModel`
-
-```python
-def evaluate(self, context: TierContext) -> TierResult:
-    # Pure function - no side effects, no shared state
-    # All inputs from context parameter
-    # All outputs in return value
-    return TierResult(...)
-```
-
-### Own Context Window
-
-Plugin manages its own context - no global state access.
-
-```python
-def get_context_for_next_tier(
-    self, result: TierResult
-) -> NextTierContext:
-    # Explicit context passing
-    # Next tier only sees what this method returns
-    return NextTierContext(
-        relevant_data=result.extract_relevant(),
-    )
-```
-
-### Structured Outputs
-
-All data uses validated models - no raw dicts.
-
-```python
-class TierResult(BaseModel):
-    score: float = Field(ge=0.0, le=1.0)
-    reasoning: str
-    metrics: dict[str, float]
-```
-
-### Own Control Flow
-
-Plugin handles its own errors and timeouts.
-
-```python
-def evaluate(self, context: TierContext) -> TierResult:
-    try:
-        result = self._compute(context)
-        return TierResult(score=result, error=None)
-    except Exception as e:
-        # Return structured error, don't raise
-        return TierResult(score=0.0, error=str(e))
-```
-
-### Compact Errors
-
-Errors produce structured partial results, not exceptions.
-
-### Single Responsibility
-
-One metric or tier per plugin.
+1. **Stateless Reducer** — `evaluate(context) -> result` as a pure function; no side effects, no shared state
+2. **Own Context Window** — plugin manages its own context; no global state access
+3. **Structured Outputs** — all data uses validated models, no raw dicts
+4. **Own Control Flow** — plugin handles its own errors and timeouts
+5. **Compact Errors** — structured partial results, not exceptions
+6. **Single Responsibility** — one metric or tier per plugin
 
 ## Plugin Design Checklist
 
@@ -117,98 +61,18 @@ Before implementing a plugin, verify:
 
 ## Implementation Template
 
-```python
-from abc import ABC, abstractmethod
-from pydantic import BaseModel, Field
-
-
-class PluginContext(BaseModel):
-    """Input context from previous tier."""
-    data: str
-    metadata: dict[str, str]
-
-
-class PluginResult(BaseModel):
-    """Structured output."""
-    score: float = Field(ge=0.0, le=1.0)
-    reasoning: str
-    error: str | None = None
-
-
-class EvaluatorPlugin(ABC):
-    @property
-    @abstractmethod
-    def name(self) -> str: ...
-
-    @property
-    @abstractmethod
-    def tier(self) -> int: ...
-
-    @abstractmethod
-    def evaluate(
-        self, context: PluginContext
-    ) -> PluginResult: ...
-
-    @abstractmethod
-    def get_context_for_next_tier(
-        self, result: PluginResult
-    ) -> BaseModel: ...
-
-
-class MyPlugin(EvaluatorPlugin):
-    def __init__(self, settings):
-        self.settings = settings
-
-    @property
-    def name(self) -> str:
-        return "my_evaluator"
-
-    @property
-    def tier(self) -> int:
-        return 1
-
-    def evaluate(
-        self, context: PluginContext
-    ) -> PluginResult:
-        try:
-            score = self._compute(context)
-            return PluginResult(
-                score=score, reasoning="...",
-            )
-        except Exception as e:
-            return PluginResult(
-                score=0.0, reasoning="", error=str(e),
-            )
-
-    def get_context_for_next_tier(
-        self, result: PluginResult
-    ) -> BaseModel:
-        return NextTierContext(score=result.score)
-
-    def _compute(self, context: PluginContext) -> float:
-        ...
-```
+See `references/plugin-implementation-template.md` for the full `EvaluatorPlugin` abstract base class and a worked `MyPlugin` example with typed context/result models, error handling, and next-tier context filtering.
 
 ## Testing Strategy
 
-Test plugins in isolation with mocked context:
+See `references/plugin-testing-strategy.md` for isolation test patterns — happy path and structured-error-handling tests using mocked context.
 
-```python
-def test_plugin_happy_path():
-    plugin = MyPlugin(settings)
-    context = PluginContext(data="test", metadata={})
-    result = plugin.evaluate(context)
-    assert result.score >= 0.0
-    assert result.error is None
+## References
 
-
-def test_plugin_error_handling():
-    plugin = MyPlugin(settings)
-    context = PluginContext(data="bad", metadata={})
-    result = plugin.evaluate(context)
-    # Structured error, not exception
-    assert result.error is not None
-```
+- `references/mas-design-principles.md` — foundational design principles (existing)
+- `references/core-principles-with-examples.md` — code examples for each of the six core principles
+- `references/plugin-implementation-template.md` — full `EvaluatorPlugin` + `MyPlugin` template
+- `references/plugin-testing-strategy.md` — isolation test patterns
 
 ## Further Reading
 

--- a/plugins/mas-design/skills/designing-mas-plugins/references/core-principles-with-examples.md
+++ b/plugins/mas-design/skills/designing-mas-plugins/references/core-principles-with-examples.md
@@ -1,0 +1,70 @@
+---
+title: MAS Plugin Core Principles — Code Examples
+description: Vulnerable/secure code patterns for each of the six core MAS plugin design principles (stateless reducer, own context, structured outputs, own control flow, compact errors, single responsibility).
+created: 2026-04-11
+category: patterns
+version: 1.0.0
+see-also: mas-design-principles.md
+---
+
+Each plugin follows six principles. This file expands each with a worked code example.
+
+## Stateless Reducer Pattern
+
+Each plugin is a pure function: `evaluate(context: BaseModel) -> BaseModel`.
+
+```python
+def evaluate(self, context: TierContext) -> TierResult:
+    # Pure function - no side effects, no shared state
+    # All inputs from context parameter
+    # All outputs in return value
+    return TierResult(...)
+```
+
+## Own Context Window
+
+Plugin manages its own context — no global state access.
+
+```python
+def get_context_for_next_tier(
+    self, result: TierResult
+) -> NextTierContext:
+    # Explicit context passing
+    # Next tier only sees what this method returns
+    return NextTierContext(
+        relevant_data=result.extract_relevant(),
+    )
+```
+
+## Structured Outputs
+
+All data uses validated models — no raw dicts.
+
+```python
+class TierResult(BaseModel):
+    score: float = Field(ge=0.0, le=1.0)
+    reasoning: str
+    metrics: dict[str, float]
+```
+
+## Own Control Flow
+
+Plugin handles its own errors and timeouts.
+
+```python
+def evaluate(self, context: TierContext) -> TierResult:
+    try:
+        result = self._compute(context)
+        return TierResult(score=result, error=None)
+    except Exception as e:
+        # Return structured error, don't raise
+        return TierResult(score=0.0, error=str(e))
+```
+
+## Compact Errors
+
+Errors produce structured partial results, not exceptions. No code example — this is an architectural choice enforced by the return type signature (`PluginResult` with optional `error: str | None`).
+
+## Single Responsibility
+
+One metric or tier per plugin. No code example — this is a scoping rule: if a plugin would own two tiers or compute three unrelated metrics, split it into multiple plugins.

--- a/plugins/mas-design/skills/designing-mas-plugins/references/plugin-implementation-template.md
+++ b/plugins/mas-design/skills/designing-mas-plugins/references/plugin-implementation-template.md
@@ -1,0 +1,82 @@
+---
+title: MAS Plugin Implementation Template
+description: Full EvaluatorPlugin abstract base class and a worked MyPlugin example with typed context/result models, error handling, and next-tier context filtering.
+created: 2026-04-11
+category: template
+version: 1.0.0
+see-also: core-principles-with-examples.md
+---
+
+Complete implementation template for a MAS evaluator plugin. Copy and adapt. Follows the six core principles documented in `core-principles-with-examples.md`.
+
+```python
+from abc import ABC, abstractmethod
+from pydantic import BaseModel, Field
+
+
+class PluginContext(BaseModel):
+    """Input context from previous tier."""
+    data: str
+    metadata: dict[str, str]
+
+
+class PluginResult(BaseModel):
+    """Structured output."""
+    score: float = Field(ge=0.0, le=1.0)
+    reasoning: str
+    error: str | None = None
+
+
+class EvaluatorPlugin(ABC):
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def tier(self) -> int: ...
+
+    @abstractmethod
+    def evaluate(
+        self, context: PluginContext
+    ) -> PluginResult: ...
+
+    @abstractmethod
+    def get_context_for_next_tier(
+        self, result: PluginResult
+    ) -> BaseModel: ...
+
+
+class MyPlugin(EvaluatorPlugin):
+    def __init__(self, settings):
+        self.settings = settings
+
+    @property
+    def name(self) -> str:
+        return "my_evaluator"
+
+    @property
+    def tier(self) -> int:
+        return 1
+
+    def evaluate(
+        self, context: PluginContext
+    ) -> PluginResult:
+        try:
+            score = self._compute(context)
+            return PluginResult(
+                score=score, reasoning="...",
+            )
+        except Exception as e:
+            return PluginResult(
+                score=0.0, reasoning="", error=str(e),
+            )
+
+    def get_context_for_next_tier(
+        self, result: PluginResult
+    ) -> BaseModel:
+        return NextTierContext(score=result.score)
+
+    def _compute(self, context: PluginContext) -> float:
+        ...
+```

--- a/plugins/mas-design/skills/designing-mas-plugins/references/plugin-testing-strategy.md
+++ b/plugins/mas-design/skills/designing-mas-plugins/references/plugin-testing-strategy.md
@@ -1,0 +1,27 @@
+---
+title: MAS Plugin Testing Strategy
+description: Isolation test patterns for MAS plugins. Happy path and structured-error-handling tests using mocked context.
+created: 2026-04-11
+category: patterns
+version: 1.0.0
+see-also: plugin-implementation-template.md
+---
+
+Test plugins in isolation with mocked context. Two minimum test classes: happy path and error handling. Both assert on the structured `PluginResult` — never expect exceptions to propagate.
+
+```python
+def test_plugin_happy_path():
+    plugin = MyPlugin(settings)
+    context = PluginContext(data="test", metadata={})
+    result = plugin.evaluate(context)
+    assert result.score >= 0.0
+    assert result.error is None
+
+
+def test_plugin_error_handling():
+    plugin = MyPlugin(settings)
+    context = PluginContext(data="bad", metadata={})
+    result = plugin.evaluate(context)
+    # Structured error, not exception
+    assert result.error is not None
+```

--- a/plugins/mas-design/skills/securing-mas/SKILL.md
+++ b/plugins/mas-design/skills/securing-mas/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   allowed-tools: Read, Grep, Glob, WebSearch, WebFetch
   argument-hint: [component-or-feature]
   stability: stable
-  content-hash: sha256:22ef3fab6a9fb01b5370f9340404ea264dc8680ccb3610d34de29cfb9459493e
+  content-hash: sha256:94039e17e94bb06a07cb298b68d4b5a02f3ef882ad08837656d1a82d3e0ad8b2
   last-verified-cc-version: 1.0.34
 ---
 
@@ -22,11 +22,6 @@ Trigger this skill when:
 - Threat modeling for multi-agent architectures
 - Reviewing plugin implementations for security
 - Designing security controls for pipelines
-
-## References
-
-**MUST READ**:
-`references/mas-security.md`
 
 ## Framework Stack
 
@@ -47,198 +42,19 @@ Use all four layers together: ATLAS enumerates attack vectors, MAESTRO maps
 them to MAS-specific controls, NIST AI RMF structures governance, and ISO
 provides the certifiable management system.
 
-## MAESTRO 7-Layer Security Check
+## Workflow
 
-For each new component, verify across all 7 layers:
+1. **Review the framework stack** — `references/mas-security.md` for the conceptual overview of MAESTRO, ATLAS, NIST AI RMF, and ISO 42001/23894 layers working together.
 
-### Layer 1: Model Layer
+2. **Apply the 7-layer security check** — for each new component, walk through every MAESTRO layer. See `references/maestro-7-layer-checklist.md` for the actionable per-layer checklist (Model → Orchestration).
 
-- [ ] No user-controlled prompts sent to LLM
-- [ ] Structured outputs prevent text injection
-- [ ] No sensitive data in model training/tuning
+3. **Run the plugin security checklist** — before marking an implementation complete, verify input validation, output safety, resource management, observability, and external dependencies. See `references/plugin-security-checklist.md`.
 
-### Layer 2: Agent Logic Layer
+4. **Document threats in the cross-framework matrix** — for each feature, map concerns to ATLAS techniques, MAESTRO layers, NIST functions, and ISO controls. Start from `references/threat-matrix-template.md` and add feature-specific rows.
 
-- [ ] All inputs validated via typed schemas
-- [ ] Type safety enforced at boundaries
-- [ ] Logic bugs prevented by typed interfaces
+5. **Avoid common vulnerability patterns** — consult `references/common-vulnerabilities.md` for vulnerable/secure code examples: prompt injection (L1), type confusion (L2), resource exhaustion (L5), secret leakage (L6).
 
-### Layer 3: Integration Layer
-
-- [ ] Timeouts configured for external services
-- [ ] Graceful degradation on service failures
-- [ ] API keys from environment variables only
-
-### Layer 4: Monitoring Layer
-
-- [ ] Structured logging (no log injection)
-- [ ] No PII in default log output
-- [ ] Trace data integrity protected
-
-### Layer 5: Execution Layer
-
-- [ ] Per-component timeout enforcement
-- [ ] Stateless design (no race conditions)
-- [ ] Resource limits configured
-
-### Layer 6: Environment Layer
-
-- [ ] Container isolation for services
-- [ ] `.env` files excluded from version control
-- [ ] Network segmentation applied
-
-### Layer 7: Orchestration Layer
-
-- [ ] Explicit execution ordering (not configurable)
-- [ ] Registry with type checking
-- [ ] Static imports (no dynamic loading)
-
-## Security Checklist for Plugins
-
-Before marking implementation as complete:
-
-### Input Validation
-
-- [ ] All inputs validated via typed model schema
-- [ ] String inputs sanitized (no code injection)
-- [ ] Numeric inputs range-checked
-- [ ] File paths validated (no directory traversal)
-
-### Output Safety
-
-- [ ] Outputs use typed validated models
-- [ ] No sensitive data in outputs (PII, API keys)
-- [ ] Error messages don't leak internal state
-- [ ] Structured errors for graceful degradation
-
-### Resource Management
-
-- [ ] Timeouts configured per component
-- [ ] Memory usage bounded (no unbounded loops)
-- [ ] File descriptors properly closed
-- [ ] Network connections have timeouts
-
-### Observability
-
-- [ ] Structured logging with context
-- [ ] Trace events emitted for debugging
-- [ ] No sensitive data in logs
-- [ ] Error paths logged for audit
-
-### External Dependencies
-
-- [ ] API keys from environment variables
-- [ ] External service failures handled gracefully
-- [ ] Retry logic with exponential backoff
-- [ ] Circuit breaker for cascading failures
-
-## Common Vulnerabilities
-
-### Prompt Injection (Layer 1)
-
-**Vulnerable**:
-
-```python
-prompt = f"Evaluate: {user_input}"
-```
-
-**Secure**:
-
-```python
-result = agent.run(EvalContext(text=user_input))
-```
-
-### Type Confusion (Layer 2)
-
-**Vulnerable**:
-
-```python
-def evaluate(self, context: dict) -> dict:
-    return {"score": context["data"]}
-```
-
-**Secure**:
-
-```python
-def evaluate(
-    self, context: EvalContext
-) -> EvalResult:
-    return EvalResult(score=context.compute())
-```
-
-### Resource Exhaustion (Layer 5)
-
-**Vulnerable**:
-
-```python
-def evaluate(self, context):
-    while True:  # Infinite loop
-        process(context)
-```
-
-**Secure**:
-
-```python
-def evaluate(self, context):
-    with timeout_context(self.settings.timeout):
-        return process(context)
-```
-
-### Secret Leakage (Layer 6)
-
-**Vulnerable**:
-
-```python
-api_key = "sk-1234..."  # Hardcoded
-```
-
-**Secure**:
-
-```python
-api_key = os.environ["API_KEY"]  # From env
-```
-
-## Threat Matrix Template
-
-For each new feature, document threats with cross-framework mapping:
-
-| Concern | ATLAS Technique | MAESTRO Layer | NIST Function | ISO Control |
-| ------- | --------------- | ------------- | ------------- | ----------- |
-| Prompt injection | AML.T0051 | L1 Model | MEASURE 2.6 | A.7.3 |
-| API credential theft | AML.T0096 | L3 Integration | GOVERN 1.5 | A.8 |
-| Log data leakage | AML.T0024 | L4 Monitoring | MAP 3 | A.7.5 |
-| Resource exhaustion | — | L5 Execution | MANAGE 2 | A.6.6 |
-| Supply chain compromise | AML.T0040 | L6 Environment | MAP 1.6 | A.8 |
-| Agent hijacking | AML.T0056 | L7 Orchestration | MEASURE 2.6 | A.6.4 |
-| Evaluation bias | AML.T0043 | L2 Agent Logic | MEASURE 2.5 | A.7.4 |
-
-## Security Testing
-
-Test security controls explicitly:
-
-```python
-def test_input_validation():
-    """Layer 2: Reject invalid inputs."""
-    plugin = MyPlugin(settings)
-    with pytest.raises(ValidationError):
-        plugin.evaluate(EvalContext(score=999))
-
-
-def test_timeout_enforcement():
-    """Layer 5: Prevent infinite execution."""
-    plugin = MyPlugin(settings)
-    with pytest.raises(TimeoutError):
-        plugin.evaluate(EvalContext(data="loop"))
-
-
-def test_error_message_safety():
-    """Layer 2: Don't leak internal state."""
-    plugin = MyPlugin(settings)
-    result = plugin.evaluate(
-        EvalContext(data="trigger_error")
-    )
-    assert "secret" not in result.error.lower()
-```
+6. **Test security controls explicitly** — write tests that exercise each MAESTRO layer's controls. See `references/security-testing-patterns.md` for pytest examples (input validation, timeout enforcement, error message safety).
 
 ## Further Reading
 

--- a/plugins/mas-design/skills/securing-mas/references/common-vulnerabilities.md
+++ b/plugins/mas-design/skills/securing-mas/references/common-vulnerabilities.md
@@ -1,0 +1,74 @@
+---
+title: Common MAS Vulnerabilities with Code Examples
+description: Vulnerable vs secure patterns for prompt injection, type confusion, resource exhaustion, and secret leakage. Mapped to MAESTRO layers.
+created: 2026-04-11
+category: patterns
+version: 1.0.0
+see-also: maestro-7-layer-checklist.md
+---
+
+Vulnerable vs secure code patterns for each MAESTRO layer's highest-impact vulnerability class.
+
+## Prompt Injection (Layer 1 — Model)
+
+**Vulnerable**:
+
+```python
+prompt = f"Evaluate: {user_input}"
+```
+
+**Secure**:
+
+```python
+result = agent.run(EvalContext(text=user_input))
+```
+
+## Type Confusion (Layer 2 — Agent Logic)
+
+**Vulnerable**:
+
+```python
+def evaluate(self, context: dict) -> dict:
+    return {"score": context["data"]}
+```
+
+**Secure**:
+
+```python
+def evaluate(
+    self, context: EvalContext
+) -> EvalResult:
+    return EvalResult(score=context.compute())
+```
+
+## Resource Exhaustion (Layer 5 — Execution)
+
+**Vulnerable**:
+
+```python
+def evaluate(self, context):
+    while True:  # Infinite loop
+        process(context)
+```
+
+**Secure**:
+
+```python
+def evaluate(self, context):
+    with timeout_context(self.settings.timeout):
+        return process(context)
+```
+
+## Secret Leakage (Layer 6 — Environment)
+
+**Vulnerable**:
+
+```python
+api_key = "sk-1234..."  # Hardcoded
+```
+
+**Secure**:
+
+```python
+api_key = os.environ["API_KEY"]  # From env
+```

--- a/plugins/mas-design/skills/securing-mas/references/maestro-7-layer-checklist.md
+++ b/plugins/mas-design/skills/securing-mas/references/maestro-7-layer-checklist.md
@@ -1,0 +1,52 @@
+---
+title: MAESTRO 7-Layer Security Checklist
+description: Per-layer actionable security checks for MAS components. Apply to every new component across all 7 OWASP MAESTRO layers.
+created: 2026-04-11
+category: checklist
+version: 1.0.0
+see-also: mas-security.md
+---
+
+For each new component, verify across all 7 layers:
+
+## Layer 1: Model Layer
+
+- [ ] No user-controlled prompts sent to LLM
+- [ ] Structured outputs prevent text injection
+- [ ] No sensitive data in model training/tuning
+
+## Layer 2: Agent Logic Layer
+
+- [ ] All inputs validated via typed schemas
+- [ ] Type safety enforced at boundaries
+- [ ] Logic bugs prevented by typed interfaces
+
+## Layer 3: Integration Layer
+
+- [ ] Timeouts configured for external services
+- [ ] Graceful degradation on service failures
+- [ ] API keys from environment variables only
+
+## Layer 4: Monitoring Layer
+
+- [ ] Structured logging (no log injection)
+- [ ] No PII in default log output
+- [ ] Trace data integrity protected
+
+## Layer 5: Execution Layer
+
+- [ ] Per-component timeout enforcement
+- [ ] Stateless design (no race conditions)
+- [ ] Resource limits configured
+
+## Layer 6: Environment Layer
+
+- [ ] Container isolation for services
+- [ ] `.env` files excluded from version control
+- [ ] Network segmentation applied
+
+## Layer 7: Orchestration Layer
+
+- [ ] Explicit execution ordering (not configurable)
+- [ ] Registry with type checking
+- [ ] Static imports (no dynamic loading)

--- a/plugins/mas-design/skills/securing-mas/references/plugin-security-checklist.md
+++ b/plugins/mas-design/skills/securing-mas/references/plugin-security-checklist.md
@@ -1,0 +1,45 @@
+---
+title: Plugin Security Checklist
+description: Pre-ship security checklist for plugin implementations. Input validation, output safety, resource management, observability, dependencies.
+created: 2026-04-11
+category: checklist
+version: 1.0.0
+see-also: maestro-7-layer-checklist.md
+---
+
+Before marking a plugin implementation as complete, verify every category:
+
+## Input Validation
+
+- [ ] All inputs validated via typed model schema
+- [ ] String inputs sanitized (no code injection)
+- [ ] Numeric inputs range-checked
+- [ ] File paths validated (no directory traversal)
+
+## Output Safety
+
+- [ ] Outputs use typed validated models
+- [ ] No sensitive data in outputs (PII, API keys)
+- [ ] Error messages don't leak internal state
+- [ ] Structured errors for graceful degradation
+
+## Resource Management
+
+- [ ] Timeouts configured per component
+- [ ] Memory usage bounded (no unbounded loops)
+- [ ] File descriptors properly closed
+- [ ] Network connections have timeouts
+
+## Observability
+
+- [ ] Structured logging with context
+- [ ] Trace events emitted for debugging
+- [ ] No sensitive data in logs
+- [ ] Error paths logged for audit
+
+## External Dependencies
+
+- [ ] API keys from environment variables
+- [ ] External service failures handled gracefully
+- [ ] Retry logic with exponential backoff
+- [ ] Circuit breaker for cascading failures

--- a/plugins/mas-design/skills/securing-mas/references/security-testing-patterns.md
+++ b/plugins/mas-design/skills/securing-mas/references/security-testing-patterns.md
@@ -1,0 +1,34 @@
+---
+title: MAS Security Testing Patterns
+description: Explicit test patterns for security controls, keyed to MAESTRO layers. Input validation, timeout enforcement, error message safety.
+created: 2026-04-11
+category: patterns
+version: 1.0.0
+see-also: maestro-7-layer-checklist.md
+---
+
+Test security controls explicitly — don't assume they work. Each test names the MAESTRO layer it covers.
+
+```python
+def test_input_validation():
+    """Layer 2: Reject invalid inputs."""
+    plugin = MyPlugin(settings)
+    with pytest.raises(ValidationError):
+        plugin.evaluate(EvalContext(score=999))
+
+
+def test_timeout_enforcement():
+    """Layer 5: Prevent infinite execution."""
+    plugin = MyPlugin(settings)
+    with pytest.raises(TimeoutError):
+        plugin.evaluate(EvalContext(data="loop"))
+
+
+def test_error_message_safety():
+    """Layer 2: Don't leak internal state."""
+    plugin = MyPlugin(settings)
+    result = plugin.evaluate(
+        EvalContext(data="trigger_error")
+    )
+    assert "secret" not in result.error.lower()
+```

--- a/plugins/mas-design/skills/securing-mas/references/threat-matrix-template.md
+++ b/plugins/mas-design/skills/securing-mas/references/threat-matrix-template.md
@@ -1,0 +1,20 @@
+---
+title: MAS Threat Matrix Template
+description: Cross-framework threat mapping template. Maps concerns to ATLAS techniques, MAESTRO layers, NIST functions, and ISO controls.
+created: 2026-04-11
+category: template
+version: 1.0.0
+see-also: mas-security.md
+---
+
+For each new feature, document threats with cross-framework mapping. Use this matrix as a starting template — add rows for feature-specific concerns.
+
+| Concern | ATLAS Technique | MAESTRO Layer | NIST Function | ISO Control |
+| ------- | --------------- | ------------- | ------------- | ----------- |
+| Prompt injection | AML.T0051 | L1 Model | MEASURE 2.6 | A.7.3 |
+| API credential theft | AML.T0096 | L3 Integration | GOVERN 1.5 | A.8 |
+| Log data leakage | AML.T0024 | L4 Monitoring | MAP 3 | A.7.5 |
+| Resource exhaustion | — | L5 Execution | MANAGE 2 | A.6.6 |
+| Supply chain compromise | AML.T0040 | L6 Environment | MAP 1.6 | A.8 |
+| Agent hijacking | AML.T0056 | L7 Orchestration | MEASURE 2.6 | A.6.4 |
+| Evaluation bias | AML.T0043 | L2 Agent Logic | MEASURE 2.5 | A.7.4 |

--- a/plugins/python-dev/skills/testing-python/SKILL.md
+++ b/plugins/python-dev/skills/testing-python/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   allowed-tools: Read, Grep, Glob, Edit, Write, Bash
   argument-hint: [test-scope or component-name]
   stability: stable
-  content-hash: sha256:7ec36cfc580c044cc46fd4fece46741526f9252b688e55b741223b2397d42064
+  content-hash: sha256:9c6623b8a660d59c5dbdaf72e4e00e0d9cfec0abff96a6b0b62647a3fcf8394c
   last-verified-cc-version: 1.0.34
 ---
 


### PR DESCRIPTION
## Summary

Closes two of three hotspots from #103 (skill context-bloat audit). Both `mas-design` skills now follow the `hardening-codebase` progressive-disclosure exemplar.

**Line counts:**
- `securing-mas/SKILL.md`: **252 → 68 lines** (−184)
- `designing-mas-plugins/SKILL.md`: **219 → 83 lines** (−136)

Both well under the proposed `<150 line` plugin-wide convention.

## Changes

### securing-mas — 5 new reference files

| File | Contains |
|---|---|
| `references/maestro-7-layer-checklist.md` | L1-L7 actionable checklist (was inline) |
| `references/plugin-security-checklist.md` | Input/output/resource/observability/deps checks |
| `references/common-vulnerabilities.md` | Vulnerable vs secure code patterns per layer |
| `references/threat-matrix-template.md` | ATLAS × MAESTRO × NIST × ISO cross-framework mapping |
| `references/security-testing-patterns.md` | pytest security-control test patterns |

SKILL.md now keeps only: frontmatter, when-to-use, framework stack diagram, workflow with pointers, further reading.

### designing-mas-plugins — 3 new reference files

| File | Contains |
|---|---|
| `references/core-principles-with-examples.md` | Code examples for each of the 6 core principles |
| `references/plugin-implementation-template.md` | Full `EvaluatorPlugin` ABC + `MyPlugin` worked example |
| `references/plugin-testing-strategy.md` | Happy path + error handling test patterns |

SKILL.md now keeps only: frontmatter, when-to-use, core principles list (names only), design checklist, anti-patterns, workflow with pointers, further reading.

### Incidental fix

Also regenerates `python-dev/testing-python/SKILL.md` content-hash, which had drifted from its body after #94 merged without running the hash script. CI's \`verify-skill-hashes\` check would have failed on any future PR without this fix.

## Version bump

- \`mas-design\` plugin: 1.0.1 → 1.1.0 (both \`plugin.json\` and \`marketplace.json\`)

## Test plan

- [x] \`securing-mas/SKILL.md\` < 150 lines (68)
- [x] \`designing-mas-plugins/SKILL.md\` < 150 lines (83)
- [x] \`bash .github/scripts/compute-skill-hashes.sh --check\` passes (0 mismatches)
- [x] \`python3 -m json.tool .claude-plugin/marketplace.json\` valid
- [x] No behavior changes — all extracted content reachable via \`references/\` pointers from SKILL.md body
- [ ] Install plugin locally and verify \`/securing-mas\` and \`/designing-mas-plugins\` still load

Refs #103

🤖 Generated with Claude <noreply@anthropic.com>