### PR TITLE
refactor(cc-meta): split synthesizing-cc-bigpicture into references (#103)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,7 +36,7 @@
       "name": "cc-meta",
       "source": "./plugins/cc-meta",
       "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
-      "version": "1.14.0"
+      "version": "1.15.0"
     },
     {
       "name": "backend-design",

--- a/plugins/cc-meta/.claude-plugin/plugin.json
+++ b/plugins/cc-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-meta",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
   "author": {
     "name": "Claude Code Utils Contributors"

--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/SKILL.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/SKILL.md
@@ -41,24 +41,6 @@ directories (`-` → `/` in encoding). Substring match on any path segment.
 /synthesizing-cc-bigpicture all 30d ./bigpicture.md  # All, 30 days, custom path
 ```
 
-## Two Reasoning Axes
-
-Track per work stream to surface where you are and what shift is needed.
-
-### Diverge / Converge
-
-- **Diverge**: Expanding — brainstorming, exploring options, opening questions
-- **Converge**: Narrowing — selecting approaches, committing, closing decisions
-- **Signals**: Open questions in plans = diverging. Task completion clustering = converging.
-- **Alert**: Diverging for N sessions without convergence → decision debt
-
-### Strategic / Tactical
-
-- **Strategic** (top-down, deductive): Principles → plans → tasks. PRD → architecture → implementation.
-- **Tactical** (bottom-up, inductive): Observations → patterns → principles. Bugs → learnings → plan revisions.
-- **Signals**: PRD→task flow = strategic. AGENT_LEARNINGS, blockers→revisions = tactical.
-- **Alert**: All strategic (no implementation feedback) or all tactical (reactive without direction)
-
 ## When to Use
 
 - Starting a work session — orient across projects
@@ -71,25 +53,6 @@ Track per work stream to surface where you are and what shift is needed.
 - Searching a specific past conversation (use `/resume` or `/history`)
 - Per-session context (session-memory does this automatically)
 - Real-time usage monitoring (use `/insights`)
-
-## CC Data Sources
-
-```
-~/.claude/
-├── history.jsonl                    # Global prompt log (display, timestamp, project, sessionId)
-├── stats-cache.json                 # Daily aggregates (messageCount, sessionCount, toolCallCount)
-├── projects/<encoded-path>/
-│   ├── memory/MEMORY.md             # Per-project persistent knowledge
-│   ├── <session-uuid>.jsonl         # Full transcripts (metadata-scan only)
-│   ├── <session-uuid>/subagents/    # Subagent transcripts
-│   └── subagents/*.jsonl            # Subagent session transcripts
-├── session-summaries/*.md           # Per-session distilled summaries
-├── plans/*.md                       # Plan mode files
-├── tasks/<session-or-team-name>/    # Tasks (*.json, skip .lock/.highwatermark)
-└── teams/<team-name>/               # config.json + inboxes/<member>.json
-```
-
-See `references/cc-entry-types.md` for JSONL entry type reference.
 
 ## Project Filtering
 
@@ -123,58 +86,24 @@ respect the filter. Apply these rules once, consistently:
    Tier 1 (metadata-only).
 
 5. **Collect signals** — Following the progressive retrieval tiers, collect
-   signals starting from Tier 1 (sequential, metadata-first, no subagents):
-   - **Activity**: `stats-cache.json` — daily counts for trajectory
-   - **Sessions**: `history.jsonl` — unique sessionIds, timestamps, topics
-   - **Memory**: `projects/*/memory/MEMORY.md` — persistent knowledge
-   - **Plans**: `plans/*.md` — goals, open questions, decisions
-   - **Tasks**: `tasks/*/*.json` — dependency graph, status
-   - **Teams**: `teams/*/config.json` + `inboxes/*.json` — structure, comms
-   - **Session summaries**: `session-summaries/*.md` — distilled session insights (skip if directory absent)
-   - **Session metadata**: First+last 5 lines of `.jsonl` — timestamps, branches
-   - **Subagent transcripts**: Glob `~/.claude/projects/*/subagents/*.jsonl`,
-     read first 5 + last 5 lines of each (cap at 10 most recent by mtime).
-     Extract: agent name/type, task summary, outcome (success/error), duration.
-   - **Project docs**: Decoded project path → `CHANGELOG.md`, `AGENT_REQUESTS.md`
+   signals starting from Tier 1. See `references/cc-data-sources.md` for the
+   full data source layout. Walk these in order (sequential, metadata-first,
+   no subagents):
+   - `stats-cache.json`, `history.jsonl`, project memory, plans, tasks, teams
+   - Session metadata (first+last 5 lines of each `.jsonl`)
+   - Session summaries (skip if directory absent)
+   - Subagent transcripts (first+last 5 lines, cap 10 most recent by mtime)
+   - Project docs (`CHANGELOG.md`, `AGENT_REQUESTS.md`)
 
-   **Critical**: Never bulk-read full `.jsonl` transcripts. Use `history.jsonl`
-   for discovery and first+last lines for metadata only.
-
-6. **Classify reasoning modes** per work stream:
-   - Open questions vs. closed decisions → diverge/converge
-   - Plan-driven tasks vs. learning entries → strategic/tactical
-   - Flag imbalances (see alerts above)
+6. **Classify reasoning modes** per work stream — diverge/converge and
+   strategic/tactical. See `references/reasoning-modes.md` for axis definitions,
+   signals, and alert conditions.
 
 7. **Synthesize** — Group by project → time clusters. Link plans↔sessions↔tasks.
    Surface blockers, trajectory, recurring themes, cross-project connections.
 
-8. **Output** using format below. Write to output path.
-
-## Output Format
-
-```markdown
-# Big Picture — <date>
-
-## Reasoning Mode Summary
-| Project | Phase | D/C | S/T | Alert |
-|---------|-------|-----|-----|-------|
-
-## Active Work Streams
-### <Project>
-- **Status:** active/stalled — N sessions in last 7d
-- **Focus:** <from memory, session summaries + latest sessions>
-- **Mode:** <diverging+tactical = exploring> | <converging+strategic = building>
-- **Key decisions / Open questions:** <from plans>
-- **Tasks:** N open / N total — blockers: <list>
-- **Subagent activity:** <if present, summarize recent agent runs: type, outcome>
-- **Trajectory:** accelerating/steady/stalled
-
-## Cross-Project Connections
-## Active Plans
-## TODOs & DONEs
-## Blockers & Stale Items
-## Mode Transitions Needed
-```
+8. **Output** using the template in `references/output-template.md`. Write to
+   output path.
 
 ## Common Pitfalls
 
@@ -192,4 +121,8 @@ respect the filter. Apply these rules once, consistently:
 
 ## References
 
-See `references/cc-entry-types.md` for JSONL session entry type taxonomy.
+- `references/progressive-retrieval.md` — tier escalation rule and cost estimates
+- `references/cc-data-sources.md` — full `~/.claude/` directory layout
+- `references/cc-entry-types.md` — JSONL session entry type taxonomy
+- `references/reasoning-modes.md` — diverge/converge and strategic/tactical axes
+- `references/output-template.md` — standard output format

--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/cc-data-sources.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/cc-data-sources.md
@@ -1,0 +1,20 @@
+# Claude Code Data Sources for Big-Picture Synthesis
+
+Full layout of the `~/.claude/` directory as consumed by `synthesizing-cc-bigpicture`. For the JSONL entry type taxonomy (fields inside each file), see `cc-entry-types.md`.
+
+```text
+~/.claude/
+├── history.jsonl                    # Global prompt log (display, timestamp, project, sessionId)
+├── stats-cache.json                 # Daily aggregates (messageCount, sessionCount, toolCallCount)
+├── projects/<encoded-path>/
+│   ├── memory/MEMORY.md             # Per-project persistent knowledge
+│   ├── <session-uuid>.jsonl         # Full transcripts (metadata-scan only)
+│   ├── <session-uuid>/subagents/    # Subagent transcripts
+│   └── subagents/*.jsonl            # Subagent session transcripts
+├── session-summaries/*.md           # Per-session distilled summaries
+├── plans/*.md                       # Plan mode files
+├── tasks/<session-or-team-name>/    # Tasks (*.json, skip .lock/.highwatermark)
+└── teams/<team-name>/               # config.json + inboxes/<member>.json
+```
+
+**Critical:** Never bulk-read full `.jsonl` transcripts. Use `history.jsonl` for discovery and first+last 5 lines of each session transcript for metadata only.

--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/output-template.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/output-template.md
@@ -1,0 +1,34 @@
+# Big-Picture Output Template
+
+The standard markdown template for `bigpicture.md` output. Every synthesis run should produce this structure. Individual sections may be empty if no data is present, but all seven top-level headings should always appear.
+
+```markdown
+# Big Picture — <date>
+
+## Reasoning Mode Summary
+| Project | Phase | D/C | S/T | Alert |
+|---------|-------|-----|-----|-------|
+
+## Active Work Streams
+### <Project>
+- **Status:** active/stalled — N sessions in last 7d
+- **Focus:** <from memory, session summaries + latest sessions>
+- **Mode:** <diverging+tactical = exploring> | <converging+strategic = building>
+- **Key decisions / Open questions:** <from plans>
+- **Tasks:** N open / N total — blockers: <list>
+- **Subagent activity:** <if present, summarize recent agent runs: type, outcome>
+- **Trajectory:** accelerating/steady/stalled
+
+## Cross-Project Connections
+## Active Plans
+## TODOs & DONEs
+## Blockers & Stale Items
+## Mode Transitions Needed
+```
+
+## Notes
+
+- **Reasoning Mode Summary** — one row per active project. `D/C` = Diverge/Converge axis, `S/T` = Strategic/Tactical axis. See `reasoning-modes.md` for classification signals.
+- **Active Work Streams** — one H3 block per project. Skip projects with zero activity in the time range.
+- **Cross-Project Connections** — this is the ONE section allowed to reference projects outside the filter scope when `project-name` is set (as outbound links).
+- **Mode Transitions Needed** — populated only when Alerts fired in the Reasoning Mode Summary (e.g., "Diverging for N sessions without convergence").

--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/reasoning-modes.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/reasoning-modes.md
@@ -1,0 +1,17 @@
+# Two Reasoning Axes
+
+Track per work stream to surface where you are and what shift is needed. The axes are orthogonal — any work stream can be classified on both simultaneously.
+
+## Diverge / Converge
+
+- **Diverge**: Expanding — brainstorming, exploring options, opening questions
+- **Converge**: Narrowing — selecting approaches, committing, closing decisions
+- **Signals**: Open questions in plans = diverging. Task completion clustering = converging.
+- **Alert**: Diverging for N sessions without convergence → decision debt
+
+## Strategic / Tactical
+
+- **Strategic** (top-down, deductive): Principles → plans → tasks. PRD → architecture → implementation.
+- **Tactical** (bottom-up, inductive): Observations → patterns → principles. Bugs → learnings → plan revisions.
+- **Signals**: PRD→task flow = strategic. AGENT_LEARNINGS, blockers→revisions = tactical.
+- **Alert**: All strategic (no implementation feedback) or all tactical (reactive without direction)

--- a/plugins/python-dev/skills/testing-python/SKILL.md
+++ b/plugins/python-dev/skills/testing-python/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   allowed-tools: Read, Grep, Glob, Edit, Write, Bash
   argument-hint: [test-scope or component-name]
   stability: stable
-  content-hash: sha256:7ec36cfc580c044cc46fd4fece46741526f9252b688e55b741223b2397d42064
+  content-hash: sha256:9c6623b8a660d59c5dbdaf72e4e00e0d9cfec0abff96a6b0b62647a3fcf8394c
   last-verified-cc-version: 1.0.34
 ---
 


### PR DESCRIPTION
## Summary

Third (and final) hotspot from #103 brought under the <150-line convention. Follows the same pattern as #107 (mas-design refactor) and the hardening-codebase exemplar.

**Line count:** 195 → **128 lines** (−67)

## Changes

### 3 new reference files

| File | Contains | Size |
|---|---|---|
| \`references/reasoning-modes.md\` | Diverge/Converge + Strategic/Tactical axes, signals, alerts | 17 lines |
| \`references/cc-data-sources.md\` | Full \`~/.claude/\` directory layout (ASCII tree) | 20 lines |
| \`references/output-template.md\` | Standard \`bigpicture.md\` output template with notes | 34 lines |

### SKILL.md body retained

Only the actionable workflow content remains inline:
- frontmatter, arguments table, when/don't-use
- project filtering rules (7-step list)
- 8-step workflow with pointers to references
- common pitfalls + quality check
- references section listing all 5 ref files

## Incidental fix

Regenerates \`python-dev/testing-python/SKILL.md\` content-hash — same pre-existing drift fix as #107. This branch was forked from main before #107 merges, so the fix needs to be in both PRs. Post-merge, both branches converge on the same hash byte-for-byte (sha256 is deterministic), so the second merge is a no-op for that file.

## Version bump

- \`cc-meta\` plugin: 1.14.0 → 1.15.0 (both \`plugin.json\` and \`marketplace.json\`)

## Test plan

- [x] \`synthesizing-cc-bigpicture/SKILL.md\` < 150 lines (128)
- [x] \`bash .github/scripts/compute-skill-hashes.sh --check\` passes (0 mismatches)
- [x] \`python3 -m json.tool .claude-plugin/marketplace.json\` valid
- [x] All 5 reference files present and linked from SKILL.md body
- [ ] Install plugin locally and verify \`/synthesizing-cc-bigpicture\` still loads
- [ ] Merge order: #107 first, then this PR (avoid marketplace.json rebase conflict if possible)

Refs #103

🤖 Generated with Claude <noreply@anthropic.com>