### PR TITLE
refactor: description audit fix + skill-authoring rule (#103)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -90,7 +90,7 @@
       "name": "docs-governance",
       "source": "./plugins/docs-governance",
       "description": "Audit and maintain documentation hierarchy and agent governance files",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "name": "market-research",

--- a/.claude/rules/skill-authoring.md
+++ b/.claude/rules/skill-authoring.md
@@ -1,0 +1,82 @@
+# Skill Authoring
+
+Constraints for every `plugins/<name>/skills/<skill-name>/SKILL.md` file in this
+repository. Enforced by issue #103 audit; see `plugins/codebase-tools/skills/hardening-codebase/`
+as the canonical exemplar.
+
+## Tooling pointer
+
+Anthropic publishes [`skill-creator`](https://claude.com/plugins/skill-creator)
+(source: [anthropics/skills](https://github.com/anthropics/skills)) as an
+**installable plugin** (not bundled by default with Claude Code). It scaffolds
+`SKILL.md` + `references/scripts/assets/` subdirs and runs an automated
+description-optimization eval loop. Contributors are encouraged to use it for
+new skills; this rule **tightens its defaults** for this repo:
+
+- `skill-creator` uses the upstream 500-line soft cap; **this repo caps at 150**.
+- `skill-creator` has no `content-hash` or `stability` concept; **this repo
+  requires hash regeneration for `stability: stable` skills** (CI-enforced).
+- `skill-creator` scaffolds `references/` as canonical pattern; **this repo
+  makes it mandatory** (not just default).
+
+## SKILL.md body size
+
+SKILL.md body (everything after the closing frontmatter `---`) MUST stay under
+**150 lines**. Upstream Anthropic cap is 500 lines; this repo's tighter target
+reflects the large number of skills shipped (shared auto-compaction budget is
+~25k tokens across recently-invoked skills, ~5k per skill).
+
+If a skill naturally grows past 150 lines, extract reference material into
+`references/*.md` files and replace inline blocks with short pointers:
+
+```markdown
+See `references/<file>.md` for <one-line purpose>.
+```
+
+Keep in SKILL.md: frontmatter, arguments, when/don't-use, core workflow steps,
+quality check. Move to `references/`: lookup tables, code examples, output
+templates, detailed checklists, architectural diagrams.
+
+## Descriptions
+
+The `description:` field in frontmatter MUST be:
+
+1. **≤ 250 characters** (Claude Code description budget cap per skill)
+2. **Front-loaded with trigger keywords** — start with the verb and domain
+   (e.g., "Audit documentation...", "Refactor Python...", "Design MAS plugins..."),
+   NOT with generic framing like "Use this skill when..." or "A skill for..."
+3. **Concrete and specific** — name the artifacts acted on, not abstract intent
+
+Short descriptions save the shared description budget (~1% of context window,
+always loaded for every skill) and improve skill auto-activation matching.
+
+## References subdirectory
+
+Reference files MUST live in `plugins/<name>/skills/<skill-name>/references/`
+(plural, lowercase). Inside each file:
+
+- No YAML frontmatter required (existing `mas-design` references use it by
+  convention, but `hardening-codebase` and `cc-meta` references do not —
+  match the convention of the other reference files already in the same skill
+  dir)
+- Start with an H1 matching the file's purpose
+- Use H2 for sub-sections, H3 for detail
+- Include tables and code blocks freely; these files load on demand
+
+## Content-hash regeneration
+
+Skills marked `stability: stable` carry a `content-hash` field in their metadata.
+After modifying any stable SKILL.md body, regenerate hashes:
+
+```bash
+bash .github/scripts/compute-skill-hashes.sh --update
+```
+
+The `verify-skill-hashes` CI workflow blocks PRs with stale hashes.
+
+## Exemplar
+
+`plugins/codebase-tools/skills/hardening-codebase/SKILL.md` (100 lines) is the
+canonical example: 7-phase workflow inlined, reference material split into
+`references/lint-tightening-checklist.md` and `references/review-agents.md`.
+Copy its structural layout when creating or refactoring skills.

--- a/plugins/docs-governance/.claude-plugin/plugin.json
+++ b/plugins/docs-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-governance",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Audit and maintain documentation hierarchy and agent governance files",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["docs", "governance", "agents-md", "hierarchy", "audit", "single-source-of-truth"]

--- a/plugins/docs-governance/skills/enforcing-doc-hierarchy/SKILL.md
+++ b/plugins/docs-governance/skills/enforcing-doc-hierarchy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: enforcing-doc-hierarchy
-description: Audits and aligns project documentation against its own declared hierarchy. Discovers authority chains from CONTRIBUTING.md (or equivalent), then detects broken links, duplicates, and misplaced content. Use when reviewing doc health, fixing stale references, or enforcing single-source-of-truth.
+description: Audit documentation against its declared hierarchy — broken links, duplicates, misplaced content, stale references, single-source-of-truth enforcement. Use for doc health reviews.
 compatibility: Designed for Claude Code
 metadata:
   argument-hint: [file-directory-or-full]


### PR DESCRIPTION
## Summary

Phase 1d+1e of #103. Scans all 61 SKILL.md files for description-field violations, fixes the single offender, and adds a plugin-wide skill-authoring convention rule.

## Description audit results

| Check | Violating count |
|---|---|
| Description > 250 chars | **1** |
| Generic-starter ("Use this skill...") | 0 |

**Length distribution:** min=66, max=295, avg=175, median=176 chars. The plugin is very well-disciplined on descriptions overall.

### The single fix

\`plugins/docs-governance/skills/enforcing-doc-hierarchy/SKILL.md\`

**Before (295 chars):**
> "Audits and aligns project documentation against its own declared hierarchy. Discovers authority chains from CONTRIBUTING.md (or equivalent), then detects broken links, duplicates, and misplaced content. Use when reviewing doc health, fixing stale references, or enforcing single-source-of-truth."

**After (179 chars):**
> "Audit documentation against its declared hierarchy — broken links, duplicates, misplaced content, stale references, single-source-of-truth enforcement. Use for doc health reviews."

All trigger keywords preserved (audit, documentation, hierarchy, broken links, duplicates, stale, single-source-of-truth, doc health). The mechanism detail ("discovers authority chains from CONTRIBUTING.md") moved out of the description — belongs in the body, not in frontmatter.

## New convention rule

\`.claude/rules/skill-authoring.md\` documents the plugin-wide SKILL.md conventions from the #103 audit:

- **SKILL.md body < 150 lines** (tighter than upstream 500 cap; reflects shared ~25k-token auto-compaction budget, ~5k per recently-invoked skill)
- **Descriptions ≤ 250 chars, front-loaded keywords** (saves the always-loaded ~1%-of-context description budget)
- **Reference material in \`references/*.md\`** subdirs
- **Content-hash regeneration** via \`.github/scripts/compute-skill-hashes.sh --update\` for stable skills

Points to \`plugins/codebase-tools/skills/hardening-codebase/\` as the canonical exemplar (100-line SKILL.md with two reference files).

## Version bump

- \`docs-governance\` plugin: 1.3.0 → 1.3.1 (description-only patch)

## Test plan

- [x] Audit script: 0 descriptions over 250 chars, 0 generic starters
- [x] New convention doc < 100 lines and matches \`.claude/rules/\` format
- [x] JSON valid in both \`marketplace.json\` and \`plugin.json\`
- [ ] Merge order note: this PR is independent of #107 and #108 — no file overlap, can merge in any order

Refs #103 (completes Phase 1d + 1e)

🤖 Generated with Claude <noreply@anthropic.com>