### PR TITLE
chore(rules): document agents/ convention in skill-authoring rule

### DIFF
--- a/.claude/rules/skill-authoring.md
+++ b/.claude/rules/skill-authoring.md
@@ -1,8 +1,10 @@
-# Skill Authoring
+# Skill and Agent Authoring
 
-Constraints for every `plugins/<name>/skills/<skill-name>/SKILL.md` file in this
-repository. Enforced by issue #103 audit; see `plugins/codebase-tools/skills/hardening-codebase/`
-as the canonical exemplar.
+Constraints for every `plugins/<name>/skills/<skill-name>/SKILL.md` and
+`plugins/<name>/agents/<agent-name>.md` file in this repository. Enforced by
+issue #103 audit; see `plugins/codebase-tools/skills/hardening-codebase/`
+as the canonical skill exemplar and `plugins/codebase-tools/agents/build-error-resolver.md`
+as the canonical agent exemplar.
 
 ## Tooling pointer
 
@@ -74,9 +76,32 @@ bash .github/scripts/compute-skill-hashes.sh --update
 
 The `verify-skill-hashes` CI workflow blocks PRs with stale hashes.
 
+## Agents convention
+
+Plugin-scoped agents live at `plugins/<name>/agents/<agent-name>.md`. There is
+**no** repo-root `.claude/agents/` directory — every agent is plugin-scoped,
+parallel to how skills are plugin-scoped.
+
+- **Host plugin selection:** pick an existing plugin whose description
+  semantically includes the agent's domain. If none fits, create a new minimal
+  plugin. See `plugins/planning/` as the minimum scaffold: `plugin.json`,
+  `README.md`, `agents/<name>.md` (no skills required).
+- **Frontmatter:** standard Claude Code agent schema (`name`, `description`,
+  `tools` array, `model`). Descriptions follow the same ≤ 250 char +
+  front-loaded trigger keywords rule as skill descriptions.
+- **README `## Agents` section:** every plugin hosting an agent MUST list it in
+  its `README.md` under an `## Agents` heading parallel to `## Skills`.
+- **Version bump:** adding or modifying an agent bumps the host plugin's
+  version in both `plugin.json` and `marketplace.json` (plugin-versioning rule).
+- **Cherry-picks from upstream:** include an attribution footer with source URL,
+  license, and adaptations. See `plugins/codebase-tools/agents/build-error-resolver.md`
+  and `plugins/planning/agents/planner.md` for the template.
+
+The canonical agent exemplar is `plugins/codebase-tools/agents/build-error-resolver.md`.
+
 ## Exemplar
 
 `plugins/codebase-tools/skills/hardening-codebase/SKILL.md` (100 lines) is the
-canonical example: 7-phase workflow inlined, reference material split into
+canonical skill example: 7-phase workflow inlined, reference material split into
 `references/lint-tightening-checklist.md` and `references/review-agents.md`.
 Copy its structural layout when creating or refactoring skills.


### PR DESCRIPTION
## Summary

Retroactive documentation of the \`plugins/<name>/agents/*.md\` convention established earlier in this session via PRs #110 and #111. New contributors adding agents wouldn't know where they belong without this update.

## Changes to \`.claude/rules/skill-authoring.md\`

1. **Title retitled** \"Skill Authoring\" → \"Skill and Agent Authoring\"
2. **New \"Agents convention\" section** covering:
   - Host plugin selection (existing plugin vs new minimal plugin — points at \`plugins/planning/\` as the minimum scaffold)
   - Frontmatter schema (\`name\`, \`description\`, \`tools\`, \`model\`)
   - README \`## Agents\` section requirement (parallel to \`## Skills\`)
   - Version bump requirement (plugin-versioning rule applies)
   - Cherry-pick attribution template for upstream imports
3. **Canonical agent exemplar**: \`plugins/codebase-tools/agents/build-error-resolver.md\`

No new conventions — just documenting what's already in main.

## Why this matters

Without the rule update, a future contributor adding an agent would either:
- Put it at \`.claude/agents/\` (wrong — not plugin-scoped)
- Put it at plugin root \`plugins/<name>/<name>.md\` (wrong — conflicts with SKILL.md convention)
- Ask where to put it (unnecessary friction)

The rule now points them at \`plugins/<name>/agents/\` with a concrete example.

## Scope

No version bump — \`.claude/rules/\` is repo-level infrastructure, not part of any plugin. This is a docs-only change.

## Test plan

- [x] Markdown renders cleanly
- [x] Points at real examples on main (\`plugins/codebase-tools/agents/build-error-resolver.md\`, \`plugins/planning/agents/planner.md\`)
- [x] Doesn't invent new conventions — only documents what's already shipped

Refs #110 #111

🤖 Generated with Claude <noreply@anthropic.com>