### PR TITLE
chore: fix 6 stale plugin READMEs from cross-repo audit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "cpp-desktop",
       "source": "./plugins/cpp-desktop",
-      "description": "C++ desktop GUI development with wxWidgets, GTK, Qt — implement, review, analyze",
+      "description": "C++ desktop GUI development with wxWidgets, GTK, Qt \u2014 implement, review, analyze",
       "version": "1.0.0"
     },
     {
@@ -60,7 +60,7 @@
       "name": "docs-generator",
       "source": "./plugins/docs-generator",
       "description": "Document generation for writeups, tech specs (ADR/RFC/design docs), and reports with pandoc PDF output",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "ralph",
@@ -72,7 +72,7 @@
       "name": "embedded-dev",
       "source": "./plugins/embedded-dev",
       "description": "Embedded firmware development with CE/FCC compliance, ESP-IDF/PlatformIO, requirement traceability, and KiCad PCB auditing",
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     {
       "name": "workspace-setup",
@@ -114,7 +114,7 @@
       "name": "gha-dev",
       "source": "./plugins/gha-dev",
       "description": "Skills and rules for creating GitHub Actions for the Marketplace",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "tdd-core",
@@ -146,25 +146,25 @@
     {
       "name": "simplify",
       "source": "./plugins/simplify",
-      "description": "Post-review code simplification — KISS, DRY, YAGNI enforcement",
-      "version": "1.0.0"
+      "description": "Post-review code simplification \u2014 KISS, DRY, YAGNI enforcement",
+      "version": "1.0.1"
     },
     {
       "name": "security-audit",
       "source": "./plugins/security-audit",
-      "description": "Code security audit — OWASP Top 10, dependency vulnerabilities, secrets detection",
-      "version": "1.0.0"
+      "description": "Code security audit \u2014 OWASP Top 10, dependency vulnerabilities, secrets detection",
+      "version": "1.0.1"
     },
     {
       "name": "makefile-core",
       "source": "./plugins/makefile-core",
       "description": "Skills and linting for consistent, rigorous Makefiles across projects",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "planning",
       "source": "./plugins/planning",
-      "description": "Feature and refactor planning agents — detailed implementation plans with phased steps, dependencies, risks, and success criteria",
+      "description": "Feature and refactor planning agents \u2014 detailed implementation plans with phased steps, dependencies, risks, and success criteria",
       "version": "1.0.0"
     }
   ]

--- a/plugins/docs-generator/.claude-plugin/plugin.json
+++ b/plugins/docs-generator/.claude-plugin/plugin.json
@@ -1,7 +1,18 @@
 {
   "name": "docs-generator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Document generation for writeups, tech specs (ADR/RFC/design docs), and reports with optional pandoc PDF export",
-  "author": { "name": "Claude Code Utils Contributors" },
-  "keywords": ["docs", "writeup", "pandoc", "citations", "adr", "rfc", "design-doc", "report"]
+  "author": {
+    "name": "Claude Code Utils Contributors"
+  },
+  "keywords": [
+    "docs",
+    "writeup",
+    "pandoc",
+    "citations",
+    "adr",
+    "rfc",
+    "design-doc",
+    "report"
+  ]
 }

--- a/plugins/docs-generator/README.md
+++ b/plugins/docs-generator/README.md
@@ -5,6 +5,8 @@ Academic/technical writeup generation with IEEE citations. PDF export via pandoc
 ## Skills
 
 - **generating-writeup** — Generates academic/technical writeups with IEEE citations and pandoc PDF output
+- **generating-tech-spec** — Generates technical specifications (ADR, RFC, design docs) with structured sections and decision rationale
+- **generating-report** — Generates structured reports (project status, analysis, findings) with executive summary and recommendations
 
 ## Demo
 

--- a/plugins/embedded-dev/.claude-plugin/plugin.json
+++ b/plugins/embedded-dev/.claude-plugin/plugin.json
@@ -1,7 +1,20 @@
 {
   "name": "embedded-dev",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Embedded firmware development with CE/FCC compliance, ESP-IDF/PlatformIO, requirement traceability, and KiCad PCB auditing",
-  "author": { "name": "Claude Code Utils Contributors" },
-  "keywords": ["embedded", "firmware", "esp-idf", "platformio", "compliance", "misra", "kicad", "pcb", "traceability", "requirements"]
+  "author": {
+    "name": "Claude Code Utils Contributors"
+  },
+  "keywords": [
+    "embedded",
+    "firmware",
+    "esp-idf",
+    "platformio",
+    "compliance",
+    "misra",
+    "kicad",
+    "pcb",
+    "traceability",
+    "requirements"
+  ]
 }

--- a/plugins/embedded-dev/README.md
+++ b/plugins/embedded-dev/README.md
@@ -29,5 +29,5 @@ clang-tidy, clang-format, sqlite3, doxygen) via copy-if-not-exists.
 ## Install
 
 ```bash
-/plugin install embedded-dev@qte77-claude-code-utils
+claude plugin install embedded-dev@qte77-claude-code-utils
 ```

--- a/plugins/gha-dev/.claude-plugin/plugin.json
+++ b/plugins/gha-dev/.claude-plugin/plugin.json
@@ -1,1 +1,14 @@
-{"name": "gha-dev", "version": "1.1.0", "description": "Skills and rules for creating GitHub Actions for the Marketplace", "author": {"name": "Claude Code Utils Contributors"}, "keywords": ["gha", "github-actions", "marketplace", "composite-action"]}
+{
+  "name": "gha-dev",
+  "version": "1.1.1",
+  "description": "Skills and rules for creating GitHub Actions for the Marketplace",
+  "author": {
+    "name": "Claude Code Utils Contributors"
+  },
+  "keywords": [
+    "gha",
+    "github-actions",
+    "marketplace",
+    "composite-action"
+  ]
+}

--- a/plugins/gha-dev/README.md
+++ b/plugins/gha-dev/README.md
@@ -18,3 +18,9 @@ Skills for creating and publishing GitHub Actions to the Marketplace.
 ## Settings
 
 Grants Bash permissions for: `gh`, `bats`, `shellcheck`, `actionlint`.
+
+## Install
+
+```bash
+claude plugin install gha-dev@qte77-claude-code-utils
+```

--- a/plugins/makefile-core/.claude-plugin/plugin.json
+++ b/plugins/makefile-core/.claude-plugin/plugin.json
@@ -1,9 +1,15 @@
 {
   "name": "makefile-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Skills and linting for consistent, rigorous Makefiles across projects",
   "author": {
     "name": "Claude Code Utils Contributors"
   },
-  "keywords": ["makefile", "make", "build", "automation", "lint"]
+  "keywords": [
+    "makefile",
+    "make",
+    "build",
+    "automation",
+    "lint"
+  ]
 }

--- a/plugins/makefile-core/README.md
+++ b/plugins/makefile-core/README.md
@@ -20,3 +20,9 @@ Skills and linting for consistent, rigorous Makefiles across projects.
 # Standalone lint
 bash plugins/makefile-core/skills/creating-makefile/references/lint-makefile.sh
 ```
+
+## Install
+
+```bash
+claude plugin install makefile-core@qte77-claude-code-utils
+```

--- a/plugins/security-audit/.claude-plugin/plugin.json
+++ b/plugins/security-audit/.claude-plugin/plugin.json
@@ -1,6 +1,8 @@
 {
   "name": "security-audit",
-  "version": "1.0.0",
-  "description": "Code security auditing — OWASP Top 10, dependency scanning, secrets detection",
-  "author": { "name": "qte77" }
+  "version": "1.0.1",
+  "description": "Code security auditing \u2014 OWASP Top 10, dependency scanning, secrets detection",
+  "author": {
+    "name": "qte77"
+  }
 }

--- a/plugins/security-audit/README.md
+++ b/plugins/security-audit/README.md
@@ -1,7 +1,15 @@
 # security-audit
 
-Code security auditing plugin with three skills:
+Code security auditing plugin with three skills for repo-wide audits. For diff-scoped security review, use Claude Code's built-in `/security-review` command instead.
+
+## Skills
 
 - **auditing-code-security** — OWASP Top 10 vulnerability audit with structured findings
 - **scanning-dependencies** — Dependency vulnerability scanning, license compliance, supply chain risk
 - **detecting-secrets** — Secrets and credential detection across files and git history
+
+## Install
+
+```bash
+claude plugin install security-audit@qte77-claude-code-utils
+```

--- a/plugins/simplify/.claude-plugin/plugin.json
+++ b/plugins/simplify/.claude-plugin/plugin.json
@@ -1,6 +1,8 @@
 {
   "name": "simplify",
-  "version": "1.0.0",
-  "description": "Review changed code for simplification — reuse, quality, efficiency. Enforces KISS, DRY, YAGNI.",
-  "author": { "name": "qte77" }
+  "version": "1.0.1",
+  "description": "Review changed code for simplification \u2014 reuse, quality, efficiency. Enforces KISS, DRY, YAGNI.",
+  "author": {
+    "name": "qte77"
+  }
 }

--- a/plugins/simplify/README.md
+++ b/plugins/simplify/README.md
@@ -24,3 +24,9 @@ KISS/DRY/YAGNI enforcement.
 /simplify              # Review staged changes
 /simplify src/foo.py   # Review specific file
 ```
+
+## Install
+
+```bash
+claude plugin install simplify@qte77-claude-code-utils
+```


### PR DESCRIPTION
## Summary

Audited all 25 plugin READMEs against actual \`skills/\` and \`agents/\` directories on disk. Found 6 with drift (9 initially flagged, 3 false positives from table-format READMEs).

## Fixes

| Plugin | Issue | Fix |
|---|---|---|
| \`docs-generator\` | Missing \`generating-tech-spec\`, \`generating-report\` from Skills | Added 2 bullet points |
| \`gha-dev\` | No Install section | Added \`claude plugin install\` command |
| \`makefile-core\` | No Install section | Added install command |
| \`security-audit\` | No Install section, no Skills heading | Added both + note about built-in \`/security-review\` for diff-scoped reviews |
| \`simplify\` | No Install section | Added install command |
| \`embedded-dev\` | Install uses old \`/plugin install\` syntax | Fixed to \`claude plugin install\` |

## False positives (no fix needed)

- \`market-research\`, \`embedded-dev\` (skills), \`simplify\` (skills): Skills listed in table format with backtick (\`\`skill-name\`\`) instead of bold (\`**skill-name**\`). Audit script initially flagged them; manual verification confirmed all skills present.
- \`workspace-sandbox\`, \`workspace-setup\`: Bold file paths in README matched the skill-detection regex. Not actual drift.

## Version bumps

| Plugin | Before | After |
|---|---|---|
| docs-generator | 1.0.1 | 1.0.2 |
| gha-dev | 1.1.0 | 1.1.1 |
| makefile-core | 1.0.0 | 1.0.1 |
| security-audit | 1.0.0 | 1.0.1 |
| simplify | 1.0.0 | 1.0.1 |
| embedded-dev | 1.2.0 | 1.2.1 |

## Test plan

- [x] All 25 READMEs now list every skill on disk (re-verified with improved audit)
- [x] JSON valid in marketplace.json and all 6 plugin.json files
- [x] Install sections use correct \`claude plugin install\` syntax

🤖 Generated with Claude <noreply@anthropic.com>