### PR TITLE
refactor(makefile-core): scaffold references for language-specific recipes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -158,8 +158,8 @@
     {
       "name": "makefile-core",
       "source": "./plugins/makefile-core",
-      "description": "Skills and linting for consistent, rigorous Makefiles across projects",
-      "version": "1.0.1"
+      "description": "Skills and linting for consistent, rigorous Makefiles across projects — auto-detects project type, extensible via scaffold-*.md references",
+      "version": "1.1.0"
     },
     {
       "name": "planning",

--- a/plugins/makefile-core/.claude-plugin/plugin.json
+++ b/plugins/makefile-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "makefile-core",
-  "version": "1.0.1",
-  "description": "Skills and linting for consistent, rigorous Makefiles across projects",
+  "version": "1.1.0",
+  "description": "Skills and linting for consistent, rigorous Makefiles across projects — auto-detects project type, extensible via scaffold-*.md references",
   "author": {
     "name": "Claude Code Utils Contributors"
   },
@@ -10,6 +10,7 @@
     "make",
     "build",
     "automation",
-    "lint"
+    "lint",
+    "scaffold"
   ]
 }

--- a/plugins/makefile-core/README.md
+++ b/plugins/makefile-core/README.md
@@ -4,22 +4,35 @@ Skills and linting for consistent, rigorous Makefiles across projects.
 
 ## Skills
 
-- `creating-makefile` — Scaffold or review Makefiles following org conventions
+- `creating-makefile` — Scaffold or review Makefiles following org conventions. Auto-detects project type from the working directory and reads the matching `scaffold-*.md` reference for language-specific recipes.
 
 ## References
 
 - `makefile-conventions.md` — Required structure, naming, and patterns
 - `lint-makefile.sh` — Bash linter for CI enforcement
+- `scaffold-*.md` — Language-specific recipe templates (shipped examples; not exhaustive — the skill works for any project type by applying conventions from first principles)
 
 ## Usage
 
 ```bash
 # In Claude Code
-/creating-makefile my-project
+/creating-makefile              # auto-detects project type from cwd
+/creating-makefile python       # override detection with explicit type
+/creating-makefile ~/my-project # target a specific directory
 
 # Standalone lint
 bash plugins/makefile-core/skills/creating-makefile/references/lint-makefile.sh
 ```
+
+## Extending
+
+To add a new project type, drop a `scaffold-<type>.md` file into `references/`. No changes to SKILL.md needed. The scaffold should provide:
+
+1. Config variables (quiet flags, tool paths)
+2. Recipes grouped under `# MARK:` sections (SETUP, DEV, at minimum)
+3. A notes section with tool-specific caveats
+
+See existing `scaffold-*.md` files for the pattern.
 
 ## Install
 

--- a/plugins/makefile-core/skills/creating-makefile/SKILL.md
+++ b/plugins/makefile-core/skills/creating-makefile/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: creating-makefile
-description: Scaffold or review Makefiles following org conventions. Use when creating a new Makefile, auditing an existing one, or adding recipes to a project.
+description: Scaffold or review Makefiles following org conventions. Use when creating a new Makefile, auditing an existing one, or adding recipes to a project. Auto-detects project type from the working directory.
 compatibility: Designed for Claude Code
 metadata:
   allowed-tools: Read, Grep, Glob, Edit, Write, Bash
-  argument-hint: [project-name-or-makefile-path]
+  argument-hint: "[project-type-or-makefile-path]"
   stability: stable
+  content-hash: sha256:99b10f5578553e5aa4ded222da3c8955c843a3ab52aa3bcd8b007c40ac35a5a4
+  last-verified-cc-version: 1.0.34
 ---
 
 # Creating Makefiles
@@ -14,12 +16,13 @@ metadata:
 
 Creates or reviews a **rigorous, consistent Makefile** following org conventions.
 
-## Quick Reference
+## References
 
 - Required structure + patterns: `references/makefile-conventions.md`
 - CI linter script: `references/lint-makefile.sh`
+- Language-specific recipe templates: `references/scaffold-*.md`
 
-## Required Structure
+## Required Structure (all project types)
 
 Every Makefile must have these elements in order:
 
@@ -35,8 +38,8 @@ endif
 .SILENT:
 .ONESHELL:
 .PHONY: \
-	recipe_a recipe_b \
-	help
+    recipe_a recipe_b \
+    help
 .DEFAULT_GOAL := help
 
 # -- config --
@@ -56,67 +59,39 @@ endif
 - **Idempotent setup**: `command -v X >/dev/null || install X`
 - **No hardcoded paths** — use variables at top of file
 - **`VERBOSE ?= 0`** with conditional quiet flags per tool
+- **Zero-sudo installs** — use `~/.local/bin` or `~/.local/share/<tool>`, never `sudo apt/dnf`
+- **`export PATH=...`** inside recipes that invoke tools installed to a non-default prefix (e.g. user-local npm)
 
-## Scaffold by Project Type
+## Approach
 
-### Shell/BATS project
-```makefile
-# MARK: SETUP
-setup_dev:  ## Install dev dependencies
+1. **Detect** what kind of project this is — look at build files, dependency manifests, and source file types in the working directory. If `$ARGUMENTS` names a type, use that instead.
+2. **Find a scaffold** — list `references/scaffold-*.md` in this skill's directory. If one matches the detected project type, read it for language-specific recipe templates. If none matches, build recipes from first principles using the conventions above.
+3. **Merge** the scaffold's recipes with the required structure (version guard, .SILENT, .ONESHELL, .PHONY, help, config variables). The scaffold provides the MARK sections and recipe bodies; the required structure wraps them.
+4. **Check** if a Makefile already exists — if yes, review it against conventions and the scaffold. If no, create one from the merged template.
+5. **Lint** with `references/lint-makefile.sh` — fix any failures.
+6. **Verify** `make help` renders all recipes, `make validate` (or `make lint`) runs clean.
 
-# MARK: QUALITY
-test:       ## Run tests (VERBOSE=1 for full output)
-lint:       ## Run shellcheck/actionlint
-validate: lint test  ## Full validation
+The scaffold files shipped with this skill are **starting points, not an exhaustive list**. For a project type without a matching scaffold, apply the same conventions and recipe structure — the patterns (setup, dev, help) are universal.
 
-# MARK: CLEANUP
-clean:      ## Remove artifacts
-
-# MARK: HELP
-help:       ## Show available recipes
-```
-
-### Python (uv) project
-```makefile
-# MARK: SETUP
-setup_dev:  ## Install dev + test dependencies
-
-# MARK: QUALITY
-test:       ## Run pytest
-lint:       ## Ruff format + check
-check_types: ## Pyright
-validate: lint check_types test  ## Full validation
-
-# MARK: HELP
-help:       ## Show available recipes
-```
-
-## Help Recipe (standard pattern)
+## Help Recipe (include in every Makefile)
 
 ```makefile
 help:  ## Show available recipes grouped by section
-	@echo "Usage: make [recipe]"
-	@echo ""
-	@awk '/^# MARK:/ { \
-		section = substr($$0, index($$0, ":")+2); \
-		printf "\n\033[1m%s\033[0m\n", section \
-	} \
-	/^[a-zA-Z0-9_-]+:.*?##/ { \
-		helpMessage = match($$0, /## (.*)/); \
-		if (helpMessage) { \
-			recipe = $$1; \
-			sub(/:/, "", recipe); \
-			printf "  \033[36m%-22s\033[0m %s\n", recipe, substr($$0, RSTART + 3, RLENGTH) \
-		} \
-	}' $(MAKEFILE_LIST)
+    echo "Usage: make [recipe]"
+    echo ""
+    awk '/^# MARK:/ { \
+        section = substr($$0, index($$0, ":")+2); \
+        printf "\n\033[1m%s\033[0m\n", section \
+    } \
+    /^[a-zA-Z0-9_-]+:.*?##/ { \
+        helpMessage = match($$0, /## (.*)/); \
+        if (helpMessage) { \
+            recipe = $$1; \
+            sub(/:/, "", recipe); \
+            printf "  \033[36m%-22s\033[0m %s\n", recipe, substr($$0, RSTART + 3, RLENGTH) \
+        } \
+    }' $(MAKEFILE_LIST)
 ```
-
-## Workflow
-
-1. **Check** if Makefile exists — create or review
-2. **Lint** with `references/lint-makefile.sh` — fix any failures
-3. **Verify** `make` shows help, `make validate` runs clean
-4. **Commit** Makefile changes
 
 ## Quality Gates
 
@@ -128,4 +103,5 @@ help:  ## Show available recipes grouped by section
 - [ ] `snake_case` recipe names only
 - [ ] `help` recipe with standard awk pattern
 - [ ] `VERBOSE ?= 0` with quiet mode support
+- [ ] No `sudo` in setup recipes (user-local installs only)
 - [ ] `lint-makefile.sh` passes

--- a/plugins/makefile-core/skills/creating-makefile/references/makefile-conventions.md
+++ b/plugins/makefile-core/skills/creating-makefile/references/makefile-conventions.md
@@ -25,8 +25,11 @@
 ### Idempotent setup
 ```makefile
 setup_dev:
-	command -v bats >/dev/null || npm install -g bats
-	command -v shellcheck >/dev/null || sudo apt-get install -y shellcheck
+	if ! command -v shellcheck > /dev/null 2>&1; then
+	    mkdir -p ~/.local/bin
+	    curl -sSfL "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" \
+	        | tar -xJ --strip-components=1 -C ~/.local/bin shellcheck-stable/shellcheck
+	fi
 ```
 
 ### Quiet mode
@@ -50,6 +53,23 @@ quick_validate: lint check_types  ## Fast validation (no tests)
 setup_all: setup_dev setup_cad setup_slicer  ## Install all
 ```
 
+### User-local Node.js tools
+```makefile
+NODE_DIR := $(HOME)/.local/share/node
+NODE_BIN := $(NODE_DIR)/bin
+
+check_docs: ## Lint markdown (user-local node)
+    export PATH="$(NODE_BIN):$$PATH"
+    if command -v markdownlint-cli2 > /dev/null 2>&1; then
+        markdownlint-cli2 "docs/**/*.md"
+    else
+        echo "run: make setup_mdlint"
+        exit 1
+    fi
+```
+
+The `export PATH` inside `.ONESHELL` recipes makes npm-installed tools work without the user editing `~/.bashrc`. Required for any recipe invoking `markdownlint-cli2`, `prettier`, or other npm-based tools installed to a user-local Node prefix.
+
 ## Anti-Patterns
 
 | Don't | Do |
@@ -60,3 +80,4 @@ setup_all: setup_dev setup_cad setup_slicer  ## Install all
 | Missing `.PHONY` | Full list up front |
 | No `help` recipe | Standard awk pattern |
 | `echo` for status | Rely on `.SILENT` + explicit echo only when needed |
+| `sudo apt-get install` in setup | `curl` + `tar` to `~/.local/bin` |

--- a/plugins/makefile-core/skills/creating-makefile/references/scaffold-docs.md
+++ b/plugins/makefile-core/skills/creating-makefile/references/scaffold-docs.md
@@ -1,0 +1,103 @@
+# Docs-Only Makefile Scaffold
+
+For repos that contain only markdown documentation — no code, no tests. Provides lychee (link checking) and markdownlint-cli2 (markdown style) with zero-sudo installs.
+
+## Config Variables
+
+```makefile
+NODE_VERSION ?= 22.11.0
+NODE_DIR     := $(HOME)/.local/share/node
+NODE_BIN     := $(NODE_DIR)/bin
+LOCAL_BIN    := $(HOME)/.local/bin
+```
+
+## Recipes
+
+```makefile
+# MARK: SETUP
+
+setup_node: ## Install Node.js user-locally to ~/.local/share/node (no sudo)
+    if [ -x "$(NODE_BIN)/node" ]; then
+        echo "node already installed: $$($(NODE_BIN)/node --version) (at $(NODE_DIR))"
+    elif command -v node > /dev/null 2>&1; then
+        echo "node already installed on PATH: $$(node --version)"
+    else
+        echo "Installing Node.js $(NODE_VERSION) to $(NODE_DIR) ..."
+        mkdir -p $(NODE_DIR)
+        curl -sSfL https://nodejs.org/dist/v$(NODE_VERSION)/node-v$(NODE_VERSION)-linux-x64.tar.xz \
+            | tar -xJ --strip-components=1 -C $(NODE_DIR) \
+            && echo "node installed — add to PATH: export PATH=$(NODE_BIN):$$PATH" \
+            || echo "Install failed — download manually from https://nodejs.org/dist/v$(NODE_VERSION)/"
+    fi
+
+setup_lychee: ## Install lychee link checker user-locally to ~/.local/bin (no sudo)
+    if command -v lychee > /dev/null 2>&1; then
+        echo "lychee already installed: $$(lychee --version)"
+    else
+        mkdir -p $(LOCAL_BIN)
+        curl -sSfL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
+            | tar xz -C $(LOCAL_BIN) \
+            && echo "lychee installed to $(LOCAL_BIN) — ensure it is on PATH" \
+            || echo "Install failed — download manually from https://github.com/lycheeverse/lychee/releases"
+    fi
+
+setup_mdlint: setup_node ## Install markdownlint-cli2 via user-local npm (no sudo)
+    export PATH="$(NODE_BIN):$$PATH"
+    if [ -x "$(NODE_BIN)/markdownlint-cli2" ]; then
+        echo "markdownlint-cli2 already installed: $$(markdownlint-cli2 --version 2>&1 | head -1)"
+    elif command -v markdownlint-cli2 > /dev/null 2>&1; then
+        echo "markdownlint-cli2 already installed (system PATH): $$(markdownlint-cli2 --version 2>&1 | head -1)"
+    else
+        echo "Installing markdownlint-cli2 into $(NODE_DIR) ..."
+        if [ -x "$(NODE_BIN)/npm" ] || command -v npm > /dev/null 2>&1; then
+            npm install -g markdownlint-cli2
+        else
+            echo "ERROR: npm not found after setup_node — check Node install"
+            exit 1
+        fi
+    fi
+
+setup_all: setup_lychee setup_mdlint ## Install all tooling (lychee + node + markdownlint-cli2)
+
+# MARK: DEV
+
+check_links: ## Check links with lychee
+    if command -v lychee > /dev/null 2>&1; then
+        lychee --config lychee.toml .
+    else
+        echo "lychee not installed — run: make setup_lychee"
+        exit 1
+    fi
+
+check_docs: ## Lint markdown files (reads .markdownlint.json)
+    export PATH="$(NODE_BIN):$$PATH"
+    if command -v markdownlint-cli2 > /dev/null 2>&1; then
+        markdownlint-cli2 "README.md" "CHANGELOG.md" "CONTRIBUTING.md" "docs/**/*.md"
+    else
+        echo "markdownlint-cli2 not installed — run: make setup_mdlint"
+        exit 1
+    fi
+
+autofix: ## Auto-fix markdown lint issues (markdownlint --fix)
+    export PATH="$(NODE_BIN):$$PATH"
+    if command -v markdownlint-cli2 > /dev/null 2>&1; then
+        markdownlint-cli2 --fix "README.md" "CHANGELOG.md" "CONTRIBUTING.md" "docs/**/*.md"
+    else
+        echo "markdownlint-cli2 not installed — run: make setup_mdlint"
+        exit 1
+    fi
+
+lint: check_links check_docs ## Run all linters (links + markdown)
+```
+
+## Notes
+
+- `setup_node` is the root dependency for markdownlint — `setup_mdlint` chains from it
+- `export PATH="$(NODE_BIN):$$PATH"` inside `.ONESHELL` recipes lets npm tools work without `~/.bashrc` edits
+- Adjust the file glob in `check_docs` / `autofix` to match your doc layout
+- Requires `lychee.toml` and `.markdownlint.json` config files in the repo root
+- Known autofix pitfall: `markdownlint-cli2 --fix` can corrupt reference-style link definitions if a blank line is missing between a table and the link defs block. Always grep for `^\[[^]]*\]: <http` after autofix and revert affected files.
+
+## Source
+
+Validated in production: `qte77/ai-agents-research` PR #98 (2026-04-11).

--- a/plugins/makefile-core/skills/creating-makefile/references/scaffold-python.md
+++ b/plugins/makefile-core/skills/creating-makefile/references/scaffold-python.md
@@ -1,0 +1,68 @@
+# Python (uv) Makefile Scaffold
+
+## Config Variables
+
+```makefile
+VERBOSE ?= 0
+ifeq ($(VERBOSE),0)
+RUFF_QUIET := --quiet
+PYTEST_QUIET := -q --tb=short --no-header
+PYRIGHT_QUIET := > /dev/null
+else
+RUFF_QUIET :=
+PYTEST_QUIET :=
+PYRIGHT_QUIET :=
+endif
+```
+
+## Recipes
+
+```makefile
+# MARK: SETUP
+
+setup_uv: ## Install uv package manager (if missing)
+    if command -v uv > /dev/null 2>&1; then
+        echo "uv already installed: $$(uv --version)"
+    else
+        echo "Installing uv ..."
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo ""
+        echo "NOTE: restart your shell or run 'source $$HOME/.local/bin/env' to add uv to PATH"
+    fi
+
+setup_dev: setup_uv ## Install dev + test dependencies
+    uv sync
+
+setup_all: setup_dev ## Install all dependencies + tools
+
+# MARK: DEV
+
+autofix: ## Auto-format and fix lint issues (use before committing)
+    uv run ruff format . $(RUFF_QUIET) && uv run ruff check . --fix $(RUFF_QUIET)
+
+lint: ## Check formatting + lint (fails on issues, does not fix)
+    uv run ruff format --check . $(RUFF_QUIET) && uv run ruff check . $(RUFF_QUIET)
+
+check_types: ## Run pyright type checking
+    uv run pyright app $(PYRIGHT_QUIET)
+
+test: ## Run all tests with pytest
+    uv run pytest $(PYTEST_QUIET)
+
+test_cov: ## Run tests with coverage report
+    uv run pytest --cov=app --cov-fail-under=80 $(PYTEST_QUIET)
+
+retest: ## Rerun last failed tests only
+    uv run pytest --lf -x
+
+quick_validate: lint check_types ## Fast gate (lint + type check)
+
+validate: lint check_types test_cov ## Full gate (lint + types + tests + coverage)
+```
+
+## Notes
+
+- Use `uv run` for all Python tool invocations (no global pip installs)
+- `setup_uv` is the root dependency — all other setup recipes chain from it
+- `VERBOSE ?= 0` controls quiet flags for ruff, pytest, pyright
+- `validate` is the full CI-equivalent gate; `quick_validate` skips tests for speed

--- a/plugins/makefile-core/skills/creating-makefile/references/scaffold-shell.md
+++ b/plugins/makefile-core/skills/creating-makefile/references/scaffold-shell.md
@@ -1,0 +1,37 @@
+# Shell/BATS Makefile Scaffold
+
+## Recipes
+
+```makefile
+# MARK: SETUP
+
+setup_dev: ## Install dev dependencies (shellcheck, bats)
+    if ! command -v shellcheck > /dev/null 2>&1; then
+        mkdir -p ~/.local/bin
+        SHELLCHECK_VERSION="stable"
+        curl -sSfL "https://github.com/koalaman/shellcheck/releases/download/$${SHELLCHECK_VERSION}/shellcheck-$${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+            | tar -xJ --strip-components=1 -C ~/.local/bin shellcheck-$${SHELLCHECK_VERSION}/shellcheck
+    fi
+    if ! command -v bats > /dev/null 2>&1; then
+        echo "bats not found — install via: git clone https://github.com/bats-core/bats-core && cd bats-core && ./install.sh ~/.local"
+    fi
+
+# MARK: DEV
+
+test: ## Run BATS tests
+    bats test/
+
+lint: ## Run shellcheck on all scripts
+    shellcheck scripts/*.sh
+
+validate: lint test ## Full validation (lint + test)
+
+clean: ## Remove artifacts
+    rm -rf tmp/ coverage/
+```
+
+## Notes
+
+- shellcheck installed via GitHub release binary to `~/.local/bin` (no sudo)
+- bats requires manual install or git clone (no single-binary release)
+- Adjust `test/` and `scripts/*.sh` paths to match your project layout


### PR DESCRIPTION
## Summary

Replaces inline scaffolds in SKILL.md with per-language reference files. The skill now teaches the **approach** (detect project type, find matching scaffold, merge with conventions) rather than enumerating languages. Adding a future language = drop one file, no SKILL.md changes.

**SKILL.md:** 131 -> **107 lines**

## New reference files (3)

| File | Source | Lines |
|---|---|---|
| \`scaffold-python.md\` | Extracted from inline + expanded from so101-biolab-automation | 68 |
| \`scaffold-shell.md\` | Extracted from inline + zero-sudo install pattern | 37 |
| \`scaffold-docs.md\` | NEW — lychee + markdownlint-cli2, zero-sudo Node.js | 103 |

**Deferred per YAGNI:** \`scaffold-rust.md\`, \`scaffold-cpp.md\` — language plugins already handle their tooling. The dispatch architecture supports adding them later by dropping a file.

## Convention fixes

- **makefile-conventions.md**: Fixed \`sudo apt-get install\` example to user-local \`curl\` + \`tar\` to \`~/.local/bin\`. Added \`export PATH\` pattern for user-local npm tools. Added \`sudo\` to anti-patterns table.
- **SKILL.md**: Added "Zero-sudo installs" and "\`export PATH\`" to Conventions list. Added "No sudo in setup recipes" to Quality Gates.

## Version bump

\`makefile-core\`: 1.0.1 -> 1.1.0

## Test plan

- [x] SKILL.md < 150 lines (107)
- [x] Content-hash regenerated
- [x] JSON valid
- [x] Each scaffold is self-contained with Config, Recipes, Notes sections
- [ ] \`/creating-makefile\` auto-detects project type and reads matching scaffold

Generated with Claude <noreply@anthropic.com>