### PR TITLE
fix: use repo-local statusline path in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "statusLine": {
     "type": "command",
-    "command": "bash plugins/workspace-setup/scripts/statusline.sh"
+    "command": "bash .claude/scripts/statusline.sh"
   },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,


### PR DESCRIPTION
## Summary
- Fixed `.claude/settings.json` statusline path from non-existent `plugins/workspace-setup/scripts/statusline.sh` to `.claude/scripts/statusline.sh`
- Now aligned with both `workspace-setup` and `workspace-sandbox` plugin settings

## Test plan
- [ ] Verify statusline renders correctly in this repo

🤖 Generated with Claude <noreply@anthropic.com>