### PR TITLE
chore: rename repo references to claude-code-plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "qte77-claude-code-utils",
+  "name": "qte77-claude-code-plugins",
   "owner": {
     "name": "qte77"
   },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,121 +12,121 @@
       "name": "python-dev",
       "source": "./plugins/python-dev",
       "description": "Python implementation, testing, code review skills, and scaffold adapter for Ralph loop",
-      "version": "2.1.2"
+      "version": "2.1.3"
     },
     {
       "name": "commit-helper",
       "source": "./plugins/commit-helper",
       "description": "Generate conventional commit messages and pull requests with approval workflow",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "codebase-tools",
       "source": "./plugins/codebase-tools",
       "description": "Isolated codebase research, quality hardening, and build error resolution via skills and agents",
-      "version": "1.4.0"
+      "version": "1.4.1"
     },
     {
       "name": "cpp-desktop",
       "source": "./plugins/cpp-desktop",
-      "description": "C++ desktop GUI development with wxWidgets, GTK, Qt \u2014 implement, review, analyze",
-      "version": "1.0.0"
+      "description": "C++ desktop GUI development with wxWidgets, GTK, Qt — implement, review, analyze",
+      "version": "1.0.1"
     },
     {
       "name": "cc-meta",
       "source": "./plugins/cc-meta",
       "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
-      "version": "1.15.0"
+      "version": "1.15.1"
     },
     {
       "name": "backend-design",
       "source": "./plugins/backend-design",
       "description": "Backend system architecture and API design skills",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "mas-design",
       "source": "./plugins/mas-design",
       "description": "Multi-agent system plugin design and OWASP MAESTRO security framework",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "website-audit",
       "source": "./plugins/website-audit",
       "description": "Website design research, usability audit, and WCAG accessibility audit skills",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "docs-generator",
       "source": "./plugins/docs-generator",
       "description": "Document generation for writeups, tech specs (ADR/RFC/design docs), and reports with pandoc PDF output",
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     {
       "name": "ralph",
       "source": "./plugins/ralph",
       "description": "PRD-to-JSON conversion, interactive user story builder, and PRD generation for the Ralph loop",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "embedded-dev",
       "source": "./plugins/embedded-dev",
       "description": "Embedded firmware development with CE/FCC compliance, ESP-IDF/PlatformIO, requirement traceability, and KiCad PCB auditing",
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     {
       "name": "workspace-setup",
       "source": "./plugins/workspace-setup",
       "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
-      "version": "1.3.4"
+      "version": "1.3.5"
     },
     {
       "name": "workspace-sandbox",
       "source": "./plugins/workspace-sandbox",
       "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
-      "version": "1.3.4"
+      "version": "1.3.5"
     },
     {
       "name": "docs-governance",
       "source": "./plugins/docs-governance",
       "description": "Audit and maintain documentation hierarchy and agent governance files",
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     {
       "name": "market-research",
       "source": "./plugins/market-research",
       "description": "GTM market research pipeline with teams mode parallel dispatch and configurable 2x2 strategy matrix",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "rust-dev",
       "source": "./plugins/rust-dev",
       "description": "Rust implementation, testing, and code review skills, deploys cargo permissions via SessionStart hook",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "go-dev",
       "source": "./plugins/go-dev",
       "description": "Go implementation, testing, and code review skills, deploys go tool permissions via SessionStart hook",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "gha-dev",
       "source": "./plugins/gha-dev",
       "description": "Skills and rules for creating GitHub Actions for the Marketplace",
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     {
       "name": "tdd-core",
       "source": "./plugins/tdd-core",
       "description": "Language-agnostic TDD methodology: Red-Green-Refactor, Arrange-Act-Assert, testing strategy",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "rag-core",
       "source": "./plugins/rag-core",
       "description": "Document indexing and hybrid retrieval with heading-boundary chunking, FAISS vector store, and PageIndex tree filtering",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "cc-voice",
@@ -134,32 +134,32 @@
         "source": "github",
         "repo": "qte77/cc-voice-plugin-prototype"
       },
-      "description": "E2E voice \u2014 TTS via PTY proxy (/speak), STT via Moonshine (/listen, functional).",
+      "description": "E2E voice — TTS via PTY proxy (/speak), STT via Moonshine (/listen, functional).",
       "version": "0.4.0"
     },
     {
       "name": "typescript-dev",
       "source": "./plugins/typescript-dev",
       "description": "TypeScript implementation, testing, and code review skills, deploys npm/vitest permissions via SessionStart hook",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "security-audit",
       "source": "./plugins/security-audit",
-      "description": "Code security audit \u2014 OWASP Top 10, dependency vulnerabilities, secrets detection",
-      "version": "1.0.1"
+      "description": "Code security audit — OWASP Top 10, dependency vulnerabilities, secrets detection",
+      "version": "1.0.2"
     },
     {
       "name": "makefile-core",
       "source": "./plugins/makefile-core",
       "description": "Skills and linting for consistent, rigorous Makefiles across projects — auto-detects project type, extensible via scaffold-*.md references",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "planning",
       "source": "./plugins/planning",
-      "description": "Feature and refactor planning agents \u2014 detailed implementation plans with phased steps, dependencies, risks, and success criteria",
-      "version": "1.0.0"
+      "description": "Feature and refactor planning agents — detailed implementation plans with phased steps, dependencies, risks, and success criteria",
+      "version": "1.0.1"
     }
   ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-code-utils-plugin-dev",
+  "name": "claude-code-plugins-dev",
   "image": "mcr.microsoft.com/vscode/devcontainers/python:3.13",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {}

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -1,7 +1,7 @@
 ---
 title: Plugin Development Learnings
 description: Accumulated learnings for maintaining this Claude Code plugin marketplace — schemas, repo governance, CI guards, skill/agent authoring, cherry-pick patterns, and merge-queue handling
-scope: qte77/claude-code-utils-plugin
+scope: qte77/claude-code-plugins
 updated: 2026-04-11
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for claude-code-utils plugin development.
+# Makefile for claude-code-plugins development.
 # Run `make help` to see all available recipes.
 
 .SILENT:

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 <!-- markdownlint-disable MD033 -->
 
-# qte77-claude-code-utils
+# qte77-claude-code-plugins
 
 Claude Code plugin marketplace — 25 plugins, 60 skills, 2 agents from production workflows.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-58f4c2.svg)](LICENSE)
 ![Version](https://img.shields.io/badge/version-3.3.0-58f4c2.svg)
-[![CodeQL](https://github.com/qte77/claude-code-utils-plugin/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/claude-code-utils-plugin/actions/workflows/codeql.yaml)
-[![CodeFactor](https://www.codefactor.io/repository/github/qte77/claude-code-utils-plugin/badge/main)](https://www.codefactor.io/repository/github/qte77/claude-code-utils-plugin/overview/main)
+[![CodeQL](https://github.com/qte77/claude-code-plugins/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/claude-code-plugins/actions/workflows/codeql.yaml)
+[![CodeFactor](https://www.codefactor.io/repository/github/qte77/claude-code-plugins/badge/main)](https://www.codefactor.io/repository/github/qte77/claude-code-plugins/overview/main)
 
 ## Install
 
 ```bash
-claude plugin marketplace add qte77/claude-code-utils
-claude plugin install workspace-setup@qte77-claude-code-utils
-claude plugin install python-dev@qte77-claude-code-utils
+claude plugin marketplace add qte77/claude-code-plugins
+claude plugin install workspace-setup@qte77-claude-code-plugins
+claude plugin install python-dev@qte77-claude-code-plugins
 ```
 
 <details>
@@ -25,31 +25,31 @@ claude plugin install python-dev@qte77-claude-code-utils
 
 ```bash
 # 1. Add the marketplace
-claude plugin marketplace add qte77/claude-code-utils-plugin
+claude plugin marketplace add qte77/claude-code-plugins
 
 # 2. Install all plugins (pick ONE workspace plugin)
-claude plugin install python-dev@qte77-claude-code-utils
-claude plugin install rust-dev@qte77-claude-code-utils
-claude plugin install go-dev@qte77-claude-code-utils
-claude plugin install typescript-dev@qte77-claude-code-utils
-claude plugin install cpp-desktop@qte77-claude-code-utils
-claude plugin install tdd-core@qte77-claude-code-utils
-claude plugin install commit-helper@qte77-claude-code-utils
-claude plugin install codebase-tools@qte77-claude-code-utils
-claude plugin install planning@qte77-claude-code-utils
-claude plugin install backend-design@qte77-claude-code-utils
-claude plugin install mas-design@qte77-claude-code-utils
-claude plugin install security-audit@qte77-claude-code-utils
-claude plugin install cc-meta@qte77-claude-code-utils
-claude plugin install market-research@qte77-claude-code-utils
-claude plugin install docs-generator@qte77-claude-code-utils
-claude plugin install docs-governance@qte77-claude-code-utils
-claude plugin install ralph@qte77-claude-code-utils
-claude plugin install embedded-dev@qte77-claude-code-utils
-claude plugin install gha-dev@qte77-claude-code-utils
-claude plugin install makefile-core@qte77-claude-code-utils
-claude plugin install rag-core@qte77-claude-code-utils
-claude plugin install workspace-setup@qte77-claude-code-utils    # OR workspace-sandbox
+claude plugin install python-dev@qte77-claude-code-plugins
+claude plugin install rust-dev@qte77-claude-code-plugins
+claude plugin install go-dev@qte77-claude-code-plugins
+claude plugin install typescript-dev@qte77-claude-code-plugins
+claude plugin install cpp-desktop@qte77-claude-code-plugins
+claude plugin install tdd-core@qte77-claude-code-plugins
+claude plugin install commit-helper@qte77-claude-code-plugins
+claude plugin install codebase-tools@qte77-claude-code-plugins
+claude plugin install planning@qte77-claude-code-plugins
+claude plugin install backend-design@qte77-claude-code-plugins
+claude plugin install mas-design@qte77-claude-code-plugins
+claude plugin install security-audit@qte77-claude-code-plugins
+claude plugin install cc-meta@qte77-claude-code-plugins
+claude plugin install market-research@qte77-claude-code-plugins
+claude plugin install docs-generator@qte77-claude-code-plugins
+claude plugin install docs-governance@qte77-claude-code-plugins
+claude plugin install ralph@qte77-claude-code-plugins
+claude plugin install embedded-dev@qte77-claude-code-plugins
+claude plugin install gha-dev@qte77-claude-code-plugins
+claude plugin install makefile-core@qte77-claude-code-plugins
+claude plugin install rag-core@qte77-claude-code-plugins
+claude plugin install workspace-setup@qte77-claude-code-plugins    # OR workspace-sandbox
 
 # 3. Verify
 claude plugin list
@@ -97,8 +97,8 @@ Add to `.claude/settings.json` so teammates get marketplace access:
 ```json
 {
   "extraKnownMarketplaces": {
-    "qte77-claude-code-utils": {
-      "source": { "source": "github", "repo": "qte77/claude-code-utils" }
+    "qte77-claude-code-plugins": {
+      "source": { "source": "github", "repo": "qte77/claude-code-plugins" }
     }
   }
 }
@@ -110,9 +110,9 @@ Each member installs plugins individually with `claude plugin install`.
 
 ```bash
 claude plugin list                                          # List installed
-claude plugin install python-dev@qte77-claude-code-utils    # Install
+claude plugin install python-dev@qte77-claude-code-plugins    # Install
 claude plugin update --all                                  # Update all
-claude plugin remove python-dev@qte77-claude-code-utils     # Remove
+claude plugin remove python-dev@qte77-claude-code-plugins     # Remove
 ```
 
 ## Development

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Claude Code Utils
 site_description: Claude Code plugin marketplace — 10 plugins, 15 skills from production workflows.
-repo_url: https://github.com/qte77/claude-code-utils-plugin
-repo_name: qte77/claude-code-utils-plugin
+repo_url: https://github.com/qte77/claude-code-plugins
+repo_name: qte77/claude-code-plugins
 
 theme:
   name: material

--- a/plugins/backend-design/.claude-plugin/plugin.json
+++ b/plugins/backend-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-design",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Backend system architecture and API design skills",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["backend", "architecture", "api", "pydantic"]

--- a/plugins/backend-design/README.md
+++ b/plugins/backend-design/README.md
@@ -9,5 +9,5 @@ Backend system architecture and API design skills.
 ## Install
 
 ```bash
-claude plugin install backend-design@qte77-claude-code-utils
+claude plugin install backend-design@qte77-claude-code-plugins
 ```

--- a/plugins/cc-meta/.claude-plugin/plugin.json
+++ b/plugins/cc-meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-meta",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
   "author": {
     "name": "Claude Code Utils Contributors"

--- a/plugins/cc-meta/README.md
+++ b/plugins/cc-meta/README.md
@@ -48,5 +48,5 @@ Add to your `.claude/settings.json` to auto-trigger session summaries:
 ## Install
 
 ```bash
-claude plugin install cc-meta@qte77-claude-code-utils
+claude plugin install cc-meta@qte77-claude-code-plugins
 ```

--- a/plugins/codebase-tools/.claude-plugin/plugin.json
+++ b/plugins/codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-tools",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Isolated codebase research, quality hardening, and build error resolution via skills and agents",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["research", "codebase", "exploration", "hardening", "lint", "review", "build-errors", "typescript"]

--- a/plugins/codebase-tools/README.md
+++ b/plugins/codebase-tools/README.md
@@ -16,5 +16,5 @@ Codebase research, context compaction, and build/quality support with ACE-FCA pr
 ## Install
 
 ```bash
-claude plugin install codebase-tools@qte77-claude-code-utils
+claude plugin install codebase-tools@qte77-claude-code-plugins
 ```

--- a/plugins/commit-helper/.claude-plugin/plugin.json
+++ b/plugins/commit-helper/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commit-helper",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Generate conventional commit messages and pull requests with approval workflow",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["commit", "conventional-commits", "git", "gpg", "pull-request"]

--- a/plugins/commit-helper/README.md
+++ b/plugins/commit-helper/README.md
@@ -10,5 +10,5 @@ Generate conventional commit messages and pull requests with approval workflow.
 ## Install
 
 ```bash
-claude plugin install commit-helper@qte77-claude-code-utils
+claude plugin install commit-helper@qte77-claude-code-plugins
 ```

--- a/plugins/cpp-desktop/.claude-plugin/plugin.json
+++ b/plugins/cpp-desktop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-desktop",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "C++ desktop application development with wxWidgets, GTK, and Qt frameworks",
   "author": { "name": "qte77" },
   "keywords": ["cpp", "c++", "desktop", "wxwidgets", "gtk", "qt", "cmake", "gui"]

--- a/plugins/cpp-desktop/README.md
+++ b/plugins/cpp-desktop/README.md
@@ -11,5 +11,5 @@ C++ desktop application development with wxWidgets, GTK, and Qt frameworks.
 ## Install
 
 ```bash
-claude plugin install cpp-desktop@qte77-claude-code-utils
+claude plugin install cpp-desktop@qte77-claude-code-plugins
 ```

--- a/plugins/docs-generator/.claude-plugin/plugin.json
+++ b/plugins/docs-generator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-generator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Document generation for writeups, tech specs (ADR/RFC/design docs), and reports with optional pandoc PDF export",
   "author": {
     "name": "Claude Code Utils Contributors"

--- a/plugins/docs-generator/README.md
+++ b/plugins/docs-generator/README.md
@@ -48,5 +48,5 @@ make -f $CLAUDE_PLUGIN_ROOT/Makefile setup_pdf_converter
 ## Install
 
 ```bash
-claude plugin install docs-generator@qte77-claude-code-utils
+claude plugin install docs-generator@qte77-claude-code-plugins
 ```

--- a/plugins/docs-governance/.claude-plugin/plugin.json
+++ b/plugins/docs-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-governance",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Audit and maintain documentation hierarchy and agent governance files",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["docs", "governance", "agents-md", "hierarchy", "audit", "single-source-of-truth"]

--- a/plugins/docs-governance/README.md
+++ b/plugins/docs-governance/README.md
@@ -10,5 +10,5 @@ Audit and maintain documentation hierarchy and agent governance files.
 ## Install
 
 ```bash
-claude plugin install docs-governance@qte77-claude-code-utils
+claude plugin install docs-governance@qte77-claude-code-plugins
 ```

--- a/plugins/embedded-dev/.claude-plugin/plugin.json
+++ b/plugins/embedded-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "embedded-dev",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Embedded firmware development with CE/FCC compliance, ESP-IDF/PlatformIO, requirement traceability, and KiCad PCB auditing",
   "author": {
     "name": "Claude Code Utils Contributors"

--- a/plugins/embedded-dev/README.md
+++ b/plugins/embedded-dev/README.md
@@ -29,5 +29,5 @@ clang-tidy, clang-format, sqlite3, doxygen) via copy-if-not-exists.
 ## Install
 
 ```bash
-claude plugin install embedded-dev@qte77-claude-code-utils
+claude plugin install embedded-dev@qte77-claude-code-plugins
 ```

--- a/plugins/gha-dev/.claude-plugin/plugin.json
+++ b/plugins/gha-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-dev",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Skills and rules for creating GitHub Actions for the Marketplace",
   "author": {
     "name": "Claude Code Utils Contributors"

--- a/plugins/gha-dev/README.md
+++ b/plugins/gha-dev/README.md
@@ -22,5 +22,5 @@ Grants Bash permissions for: `gh`, `bats`, `shellcheck`, `actionlint`.
 ## Install
 
 ```bash
-claude plugin install gha-dev@qte77-claude-code-utils
+claude plugin install gha-dev@qte77-claude-code-plugins
 ```

--- a/plugins/go-dev/.claude-plugin/plugin.json
+++ b/plugins/go-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-dev",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Go implementation, testing, and code review skills, deploys go tool permissions via SessionStart hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["go", "golang", "implementation", "testing", "review"]

--- a/plugins/go-dev/README.md
+++ b/plugins/go-dev/README.md
@@ -15,5 +15,5 @@ Go implementation, testing, and code review skills, deploys go tool permissions 
 ## Install
 
 ```bash
-claude plugin install go-dev@qte77-claude-code-utils
+claude plugin install go-dev@qte77-claude-code-plugins
 ```

--- a/plugins/makefile-core/.claude-plugin/plugin.json
+++ b/plugins/makefile-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "makefile-core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Skills and linting for consistent, rigorous Makefiles across projects — auto-detects project type, extensible via scaffold-*.md references",
   "author": {
     "name": "Claude Code Utils Contributors"

--- a/plugins/makefile-core/README.md
+++ b/plugins/makefile-core/README.md
@@ -37,5 +37,5 @@ See existing `scaffold-*.md` files for the pattern.
 ## Install
 
 ```bash
-claude plugin install makefile-core@qte77-claude-code-utils
+claude plugin install makefile-core@qte77-claude-code-plugins
 ```

--- a/plugins/market-research/.claude-plugin/plugin.json
+++ b/plugins/market-research/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "market-research",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "GTM market research pipeline with teams mode parallel dispatch and configurable 2x2 strategy matrix",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["market-research", "gtm", "go-to-market", "strategy", "competitive-intelligence", "product-market-fit"]

--- a/plugins/market-research/README.md
+++ b/plugins/market-research/README.md
@@ -55,5 +55,5 @@ Then continue through the pipeline phases sequentially.
 ## Install
 
 ```bash
-claude plugin install market-research@qte77-claude-code-utils
+claude plugin install market-research@qte77-claude-code-plugins
 ```

--- a/plugins/mas-design/.claude-plugin/plugin.json
+++ b/plugins/mas-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mas-design",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MAS plugin design and multi-framework security auditing (OWASP MAESTRO, MITRE ATLAS, NIST AI RMF, ISO 42001/23894)",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["mas", "multi-agent", "plugin", "security", "maestro", "owasp", "mitre", "atlas", "nist", "iso", "pydantic"]

--- a/plugins/mas-design/README.md
+++ b/plugins/mas-design/README.md
@@ -23,5 +23,5 @@ standards) — producing a unified threat matrix with cross-framework mappings.
 ## Install
 
 ```bash
-claude plugin install mas-design@qte77-claude-code-utils
+claude plugin install mas-design@qte77-claude-code-plugins
 ```

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "planning",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Feature and refactor planning agents — detailed implementation plans with phased steps, dependencies, risks, and success criteria",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["planning", "feature-planning", "implementation-plan", "refactoring", "architecture", "step-breakdown"]

--- a/plugins/planning/README.md
+++ b/plugins/planning/README.md
@@ -20,5 +20,5 @@ The `planner` agent is **prospective** (plans a specific thing); the cc-meta ski
 ## Install
 
 ```bash
-claude plugin install planning@qte77-claude-code-utils
+claude plugin install planning@qte77-claude-code-plugins
 ```

--- a/plugins/python-dev/.claude-plugin/plugin.json
+++ b/plugins/python-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-dev",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Python implementation, testing, and code review skills, deploys uv permissions via SessionStart hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["python", "implementation", "testing", "review", "pytest"]

--- a/plugins/python-dev/README.md
+++ b/plugins/python-dev/README.md
@@ -15,5 +15,5 @@ Python implementation, testing, and code review skills, deploys uv permissions v
 ## Install
 
 ```bash
-claude plugin install python-dev@qte77-claude-code-utils
+claude plugin install python-dev@qte77-claude-code-plugins
 ```

--- a/plugins/rag-core/.claude-plugin/plugin.json
+++ b/plugins/rag-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Document indexing and hybrid retrieval with heading-boundary chunking, FAISS vector store, and PageIndex tree filtering",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["rag", "retrieval", "indexing", "chunking", "faiss", "embedding"]

--- a/plugins/rag-core/README.md
+++ b/plugins/rag-core/README.md
@@ -14,5 +14,5 @@ Document indexing and hybrid retrieval for RAG pipelines.
 ## Install
 
 ```bash
-claude plugin install rag-core@qte77-claude-code-utils
+claude plugin install rag-core@qte77-claude-code-plugins
 ```

--- a/plugins/ralph/.claude-plugin/plugin.json
+++ b/plugins/ralph/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "PRD-to-JSON conversion and interactive user story builder for the Ralph loop",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["ralph", "prd", "userstory"]

--- a/plugins/ralph/README.md
+++ b/plugins/ralph/README.md
@@ -11,5 +11,5 @@ UserStory → PRD → JSON pipeline and interactive user story builder for the R
 ## Install
 
 ```bash
-claude plugin install ralph@qte77-claude-code-utils
+claude plugin install ralph@qte77-claude-code-plugins
 ```

--- a/plugins/rust-dev/.claude-plugin/plugin.json
+++ b/plugins/rust-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-dev",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rust implementation, testing, and code review skills, deploys cargo permissions via SessionStart hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["rust", "implementation", "testing", "review", "cargo"]

--- a/plugins/rust-dev/README.md
+++ b/plugins/rust-dev/README.md
@@ -15,5 +15,5 @@ Rust implementation, testing, and code review skills, deploys cargo permissions 
 ## Install
 
 ```bash
-claude plugin install rust-dev@qte77-claude-code-utils
+claude plugin install rust-dev@qte77-claude-code-plugins
 ```

--- a/plugins/security-audit/.claude-plugin/plugin.json
+++ b/plugins/security-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-audit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Code security auditing \u2014 OWASP Top 10, dependency scanning, secrets detection",
   "author": {
     "name": "qte77"

--- a/plugins/security-audit/README.md
+++ b/plugins/security-audit/README.md
@@ -11,5 +11,5 @@ Code security auditing plugin with three skills for repo-wide audits. For diff-s
 ## Install
 
 ```bash
-claude plugin install security-audit@qte77-claude-code-utils
+claude plugin install security-audit@qte77-claude-code-plugins
 ```

--- a/plugins/tdd-core/.claude-plugin/plugin.json
+++ b/plugins/tdd-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tdd-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Language-agnostic TDD methodology: Red-Green-Refactor cycle, Arrange-Act-Assert, testing strategy, anti-patterns",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["tdd", "testing", "red-green-refactor", "arrange-act-assert", "test-driven"]

--- a/plugins/tdd-core/README.md
+++ b/plugins/tdd-core/README.md
@@ -14,5 +14,5 @@ Language-agnostic TDD methodology for any project.
 ## Install
 
 ```bash
-claude plugin install tdd-core@qte77-claude-code-utils
+claude plugin install tdd-core@qte77-claude-code-plugins
 ```

--- a/plugins/typescript-dev/.claude-plugin/plugin.json
+++ b/plugins/typescript-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-dev",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TypeScript implementation, testing, and code review skills, deploys npm/vitest permissions via SessionStart hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["typescript", "react", "vitest", "vite", "implementation", "testing", "review"]

--- a/plugins/typescript-dev/README.md
+++ b/plugins/typescript-dev/README.md
@@ -16,5 +16,5 @@ TypeScript implementation, testing, and code review skills, deploys npm/vitest p
 ## Install
 
 ```bash
-claude plugin install typescript-dev@qte77-claude-code-utils
+claude plugin install typescript-dev@qte77-claude-code-plugins
 ```

--- a/plugins/website-audit/.claude-plugin/plugin.json
+++ b/plugins/website-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "website-audit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Website design research, usability audit, and WCAG accessibility audit skills",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["website", "design", "usability", "accessibility", "wcag", "ux"]

--- a/plugins/website-audit/README.md
+++ b/plugins/website-audit/README.md
@@ -22,5 +22,5 @@ producing findings with severity levels and implementable code fixes.
 ## Install
 
 ```bash
-claude plugin install website-audit@qte77-claude-code-utils
+claude plugin install website-audit@qte77-claude-code-plugins
 ```

--- a/plugins/workspace-sandbox/.claude-plugin/plugin.json
+++ b/plugins/workspace-sandbox/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-sandbox",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "sandbox", "read-once"]

--- a/plugins/workspace-sandbox/README.md
+++ b/plugins/workspace-sandbox/README.md
@@ -42,7 +42,7 @@ Based on [Bande-a-Bonnot/Boucle-framework](https://github.com/Bande-a-Bonnot/Bou
 ## Install
 
 ```bash
-claude plugin install workspace-sandbox@qte77-claude-code-utils
+claude plugin install workspace-sandbox@qte77-claude-code-plugins
 ```
 
 For defaults without sandbox, use `workspace-setup` instead.

--- a/plugins/workspace-sandbox/settings/settings-sandbox.json
+++ b/plugins/workspace-sandbox/settings/settings-sandbox.json
@@ -15,10 +15,10 @@
     "context7@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
-    "qte77-claude-code-utils": {
+    "qte77-claude-code-plugins": {
       "source": {
         "source": "github",
-        "repo": "qte77/claude-code-utils-plugin"
+        "repo": "qte77/claude-code-plugins"
       }
     }
   },

--- a/plugins/workspace-setup/.claude-plugin/plugin.json
+++ b/plugins/workspace-setup/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-setup",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "governance", "setup", "read-once"]

--- a/plugins/workspace-setup/README.md
+++ b/plugins/workspace-setup/README.md
@@ -32,7 +32,7 @@ Based on [Bande-a-Bonnot/Boucle-framework](https://github.com/Bande-a-Bonnot/Bou
 ## Install
 
 ```bash
-claude plugin install workspace-setup@qte77-claude-code-utils
+claude plugin install workspace-setup@qte77-claude-code-plugins
 ```
 
 For sandbox settings, use `workspace-sandbox` instead.

--- a/plugins/workspace-setup/settings/settings-base.json
+++ b/plugins/workspace-setup/settings/settings-base.json
@@ -15,10 +15,10 @@
     "context7@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
-    "qte77-claude-code-utils": {
+    "qte77-claude-code-plugins": {
       "source": {
         "source": "github",
-        "repo": "qte77/claude-code-utils-plugin"
+        "repo": "qte77/claude-code-plugins"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Repo renamed on GitHub from `claude-code-utils-plugin` to `claude-code-plugins`
- Updated all 32 files: marketplace name, install commands, badge URLs, settings, mkdocs, devcontainer
- `claude-code-utils-plugin` → `claude-code-plugins`
- `qte77-claude-code-utils` → `qte77-claude-code-plugins`

## Test plan
- [ ] Verify `claude plugin marketplace add qte77/claude-code-plugins` works
- [ ] Verify badge URLs resolve (CodeQL, CodeFactor)
- [ ] Spot-check install commands in plugin READMEs

## Follow-up
19 external repos need the same rename — see conversation for full list.

🤖 Generated with Claude <noreply@anthropic.com>