### PR TITLE
feat: add readme-generator plugin v1.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code utility plugins for development, architecture, auditing, documentation, market research, and CC meta-skills",
-    "version": "3.5.0"
+    "version": "3.6.0"
   },
   "plugins": [
     {
@@ -160,6 +160,12 @@
       "source": "./plugins/makefile-core",
       "description": "Skills and linting for consistent, rigorous Makefiles across projects — auto-detects project type, extensible via scaffold-*.md references",
       "version": "1.2.0"
+    },
+    {
+      "name": "readme-generator",
+      "source": "./plugins/readme-generator",
+      "description": "Generate and audit README.md files for repos, GitHub accounts, and organizations",
+      "version": "1.0.0"
     },
     {
       "name": "planning",

--- a/plugins/readme-generator/.claude-plugin/plugin.json
+++ b/plugins/readme-generator/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "readme-generator",
+  "version": "1.0.0",
+  "description": "Generate and audit README.md files for repos, GitHub accounts, and organizations",
+  "author": { "name": "Claude Code Utils Contributors" },
+  "keywords": ["readme", "profile", "organization", "github", "documentation", "audit"]
+}

--- a/plugins/readme-generator/references/readme-best-practices.md
+++ b/plugins/readme-generator/references/readme-best-practices.md
@@ -1,0 +1,59 @@
+# README Best Practices Reference
+
+## Organization Profile READMEs
+
+**File location:** `.github/profile/README.md`
+
+**Structure (150-400 words):**
+1. H1 + single-sentence mission
+2. Brief elaboration (2-3 sentences)
+3. Projects grouped by domain with inline links
+4. Get involved section with CTAs
+
+## GitHub User Profile READMEs
+
+**File location:** `<username>/<username>/README.md`
+
+**Structure (under 300 words):**
+1. Name/tagline
+2. Current focus (2-3 bullets)
+3. Featured projects (3-5 linked)
+4. Tech stack
+5. Links/contact
+
+## Repository READMEs — GitHub Actions
+
+**Standard badge set (in order, below H1):**
+1. Version — `![Version](https://img.shields.io/badge/version-X.Y.Z-8A2BE2)`
+2. License — `![License](https://img.shields.io/badge/license-Apache--2.0-blue)`
+3. GHA status — test-action workflow badge
+4. CodeFactor — `![CodeFactor](https://www.codefactor.io/repository/github/owner/repo/badge)`
+5. CodeQL — CodeQL workflow status badge
+6. Dependabot — `![Dependabot](https://img.shields.io/badge/dependabot-enabled-025e8c)`
+7. Ruff / Pytest — linter + test badges (Python actions)
+8. BATS — test framework badge (shell-based actions)
+
+**Required sections (in order):**
+1. `# repo-name` + badges
+2. One-line description
+3. `## Inputs` — table: Name | Required | Default | Description
+4. `## Outputs` — table (or "This action has no outputs.")
+5. `## Usage` — complete workflow YAML
+6. `## What it does` — numbered steps
+7. `## License` — `[License-Type](LICENSE)`
+
+**Conventions:**
+- License file is always `LICENSE` (never `LICENSE.md`)
+- Input table column order: Name | Required | Default | Description
+- Pinned action SHAs in usage examples: `@<sha> # vX.Y.Z`
+
+## Repository READMEs — Libraries
+
+**Required:** Title, description, install/quick start, `[License-Type](LICENSE)`
+
+## Cross-Repo Consistency
+
+- Input/output table column order must be consistent
+- Badge set and placement must be consistent
+- Section naming: "What it does" (preferred) or "How it works"
+- License always `LICENSE` (never `LICENSE.md`)

--- a/plugins/readme-generator/skills/auditing-readme/SKILL.md
+++ b/plugins/readme-generator/skills/auditing-readme/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: auditing-readme
+description: Audit README.md files against best practices for repos, accounts, or orgs. Detects missing sections, stale links, inconsistent formatting, and convention violations. Use when reviewing README quality across one or many repos.
+compatibility: Designed for Claude Code
+metadata:
+  argument-hint: <scope> [target-or-glob]
+  allowed-tools: Read, Grep, Glob, Bash, WebFetch, Agent
+---
+
+# Audit README
+
+**Scope**: $ARGUMENTS
+
+Audit README.md files against scope-specific best practices and report findings.
+
+## Phase 1: Detect Scope and Targets
+
+Parse `$ARGUMENTS`:
+
+- `repo` — audit README.md in the current directory
+- `repo <owner/repo>` — audit a specific remote repo's README
+- `repos <owner/pattern>` — batch audit multiple repos (e.g., `repos qte77/gha-*`)
+- `account <username>` — audit a GitHub user profile README
+- `org <orgname>` — audit an organization profile README
+
+## Phase 2: Fetch READMEs
+
+- Local repos: read README.md directly
+- Remote repos: `gh api repos/<owner>/<repo>/contents/README.md --jq '.content' | base64 -d`
+- Account profiles: `gh api repos/<user>/<user>/contents/README.md --jq '.content' | base64 -d`
+- Org profiles: try `profile/README.md` first, fall back to root `README.md` in `.github` repo
+
+## Phase 3: Run Checklist
+
+### Base Repo Checklist
+
+| # | Check | Level | Pass Condition |
+|---|-------|-------|----------------|
+| R1 | Title | required | H1 heading exists, matches repo name |
+| R2 | Description | required | Non-empty text within 3 lines of H1 |
+| R3 | Version badge | recommended | `![Version]` badge present |
+| R3b | Standard badge set | recommended | For GHA repos: version, license, CI status, CodeFactor, CodeQL, Dependabot, ruff/pytest or BATS (applicable subset) |
+| R4 | Install/Usage | required | Section with heading containing "install", "usage", "quick start", or "getting started" |
+| R5 | License | required | Section containing "license" with link to `LICENSE` (not `LICENSE.md`) |
+| R6 | Internal links valid | required | All `[text](relative-path)` links resolve to existing files |
+| R7 | LICENSE file name | required | License file must be named `LICENSE` (not `LICENSE.md`) |
+
+### GHA Extension (if `action.yml`/`action.yaml` exists)
+
+| # | Check | Level | Pass Condition |
+|---|-------|-------|----------------|
+| G1 | Inputs table | required | Markdown table under heading containing "input" |
+| G2 | Outputs table | required | Markdown table or "no outputs" statement |
+| G3 | Usage YAML | required | Fenced yaml block with `uses:` |
+| G4 | What it does | required | Section with numbered steps |
+| G5 | Input column order | recommended | Name, Required, Default, Description |
+
+### Account Profile Checklist
+
+| # | Check | Level | Pass Condition |
+|---|-------|-------|----------------|
+| A1 | Tagline | required | Non-empty text within 5 lines of first heading |
+| A2 | Current focus | recommended | Section describing current work |
+| A3 | Featured projects | recommended | 3+ repository links with descriptions |
+| A4 | Not stale | required | Updated within 6 months |
+| A5 | Scannability | recommended | Under 500 words |
+
+### Organization Profile Checklist
+
+| # | Check | Level | Pass Condition |
+|---|-------|-------|----------------|
+| O1 | File location | required | README at `.github/profile/README.md` |
+| O2 | Mission | required | Single-sentence purpose within 3 lines of H1 |
+| O3 | Activities | required | Description of what the org does |
+| O4 | Projects | recommended | Links to key repos, grouped by domain |
+| O5 | CTA | required | "Get involved" section with actionable links |
+| O6 | Length | recommended | 150-400 words |
+
+## Phase 4: Report
+
+Output a findings table per target:
+
+```
+## <repo-name>
+
+| # | Check | Level | Status | Notes |
+|---|-------|-------|--------|-------|
+
+Summary: X/Y required pass, Z/W recommended pass.
+```
+
+### Batch Summary
+
+```
+| Repo | Required | Recommended | Top Issue |
+|------|----------|-------------|-----------|
+```
+
+### Consistency Checks (batch only)
+
+- Input table column order consistent?
+- Badge style/placement consistent?
+- Section naming consistent?
+- License format consistent (`LICENSE` not `LICENSE.md`)?
+
+## Rules
+
+- Never modify files during an audit — read-only
+- Report facts, not opinions
+- License file MUST be `LICENSE` (not `LICENSE.md`) — flag as FAIL if `.md` variant used

--- a/plugins/readme-generator/skills/writing-readme/SKILL.md
+++ b/plugins/readme-generator/skills/writing-readme/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: writing-readme
+description: Generate or update README.md files for repositories, GitHub user profiles, or GitHub organizations. Use when creating a new README, updating an existing one, or converting a repo README to follow org conventions. Supports repo, account (user profile), and org (organization profile) scopes.
+compatibility: Designed for Claude Code
+metadata:
+  argument-hint: <scope> [target]
+  allowed-tools: Read, Grep, Glob, Edit, Write, Bash, WebFetch, Agent
+---
+
+# Write README
+
+**Scope**: $ARGUMENTS
+
+Generate or update a README.md following scope-specific best practices.
+
+## Phase 1: Detect Scope
+
+Parse `$ARGUMENTS` to determine scope:
+
+- `repo` (default) — README.md for a code repository in the current directory
+- `repo <owner/repo>` — README.md for a specific remote repository
+- `account <username>` — profile README for a GitHub user (`<username>/<username>/README.md`)
+- `org <orgname>` — organization profile README (`.github/profile/README.md`)
+
+If no scope is given, default to `repo` for the current working directory.
+
+## Phase 2: Gather Context
+
+### For `repo`
+
+1. Read existing README.md (if any)
+2. Detect project type:
+   - `action.yml` / `action.yaml` exists → GitHub Action
+   - `pyproject.toml` / `setup.py` → Python library
+   - `package.json` → Node.js/TypeScript
+   - `Cargo.toml` → Rust
+   - `go.mod` → Go
+3. Read project manifest for name, version, description, license
+4. Scan source tree: `src/`, `lib/`, main entry points
+5. Read LICENSE file
+6. Check for existing docs: CONTRIBUTING.md, AGENTS.md, docs/
+
+### For `account`
+
+1. `gh api users/<username>` — bio, company, location, blog
+2. `gh repo list <username> --limit 30 --json name,description,stargazerCount,primaryLanguage` — repos sorted by stars
+3. Read existing `<username>/<username>/README.md` if it exists
+4. Identify top 3-5 repos by stars or recent activity
+
+### For `org`
+
+1. `gh api orgs/<orgname>` — description, blog, location
+2. `gh repo list <orgname> --limit 50 --json name,description,isPrivate,stargazerCount,primaryLanguage` — public repos
+3. Read existing `.github/profile/README.md` or `.github/readme.md`
+4. Group repos by domain/purpose
+5. Identify pinned repos if any
+
+## Phase 3: Apply Template
+
+### Repo README — GitHub Action
+
+```markdown
+# repo-name
+
+![Version](https://img.shields.io/badge/version-X.Y.Z-8A2BE2)
+![License](https://img.shields.io/badge/license-Apache--2.0-blue)
+![Test Action](https://github.com/owner/repo/actions/workflows/test-action.yaml/badge.svg)
+![CodeFactor](https://www.codefactor.io/repository/github/owner/repo/badge)
+![CodeQL](https://github.com/owner/repo/actions/workflows/codeql.yaml/badge.svg)
+![Dependabot](https://img.shields.io/badge/dependabot-enabled-025e8c)
+<!-- Add ruff/pytest badges for Python actions, BATS badge for shell actions -->
+
+One-line description.
+
+## Inputs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| ... | ... | ... | ... |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ... | ... |
+
+## Usage
+
+\`\`\`yaml
+name: Example
+on: [push]
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: owner/repo@vX
+        with:
+          input_name: value
+\`\`\`
+
+## What it does
+
+1. Step one
+2. Step two
+3. Step three
+
+## License
+
+[License-Type](LICENSE)
+```
+
+**Conventions:**
+- Input table columns: Name | Required | Default | Description (this order)
+- Version badge immediately after H1
+- Usage section has a complete, copy-pasteable workflow
+- "What it does" uses numbered steps
+- License links to `LICENSE` file (never `LICENSE.md`)
+
+### Repo README — Library/Application
+
+```markdown
+# repo-name
+
+One-line description.
+
+## Installation
+
+\`\`\`bash
+install command
+\`\`\`
+
+## Quick Start
+
+\`\`\`python
+minimal usage example
+\`\`\`
+
+## License
+
+[License-Type](LICENSE)
+```
+
+### Account Profile README
+
+```markdown
+# Display Name
+
+Tagline or bio — who you are in one sentence.
+
+### Current focus
+
+- What you're working on now (2-3 bullets)
+
+### Projects
+
+- [**project-name**](url) — one-line description
+- [**project-name**](url) — one-line description
+
+### Tools & languages
+
+Python · Rust · TypeScript · ...
+```
+
+### Organization Profile README
+
+```markdown
+# Org Name
+
+Single-sentence mission.
+
+Optional 2-3 sentence elaboration.
+
+---
+
+### What we build
+
+**Domain 1** — brief description with inline links to
+[key-repo-1](url) and [key-repo-2](url).
+
+### Get involved
+
+- CTA 1 → [link](url)
+- Open an issue or PR on any repo.
+```
+
+**Conventions:**
+- File MUST be at `.github/profile/README.md`
+- 150-400 words total
+- License always links to `LICENSE` (never `LICENSE.md`)
+
+## Phase 4: Generate
+
+1. Draft the README applying the appropriate template
+2. Verify all links resolve
+3. Present the draft to the user for review
+4. Write the file after user approval
+
+## Rules
+
+- Never add content the project doesn't have
+- Keep descriptions factual — pull from existing docs, manifests, and code
+- Don't add emojis unless the user requests them
+- Prefer brevity — every sentence should earn its place
+- For org READMEs: omit private repos unless the user explicitly asks
+- License file is always `LICENSE` (never `LICENSE.md`)


### PR DESCRIPTION
## Summary
- Add `readme-generator` plugin with two skills: `writing-readme` and `auditing-readme`
- Add `references/readme-best-practices.md` with codified conventions
- Bump marketplace version to 3.6.0
- Enforces `LICENSE` (never `LICENSE.md`) throughout

## Skills
- **writing-readme** — generate/update READMEs for repos (GHA/library), user profiles, org profiles
- **auditing-readme** — audit READMEs against checklists with batch mode and cross-repo consistency checks

Generated with Claude <noreply@anthropic.com>