### PR TITLE
chore: canonical Apache-2.0 LICENSE + governance files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# Agent Instructions
+
+**Behavioral rules, compliance requirements, and decision frameworks for AI coding
+agents.** For technical workflows and coding standards, see
+[CONTRIBUTING.md](CONTRIBUTING.md). For project overview, see
+[README.md](README.md).
+
+**External References:**
+
+- @CONTRIBUTING.md - Command reference, testing guidelines, code style patterns
+- @AGENT_REQUESTS.md - Escalation and human collaboration
+- @AGENT_LEARNINGS.md - Pattern discovery and knowledge sharing
+
+## Claude Code Infrastructure
+
+**Rules** (`.claude/rules/`): Session-loaded constraints (always active)
+**Skills** (`.claude/skills/`): Modular capabilities with progressive disclosure
+
+## Core Rules & AI Behavior
+
+- Follow SDLC principles: maintainability, modularity, reusability, adaptability
+- **Never assume missing context** - Ask questions if uncertain about requirements
+- **Never hallucinate libraries** - Only use packages verified in project dependencies
+- **Always confirm file paths exist** before referencing in code or tests
+- **Never delete existing code** unless explicitly instructed or documented refactoring
+- **Document new patterns** in AGENT_LEARNINGS.md (concise, laser-focused, streamlined)
+- **Request human feedback** in AGENT_REQUESTS.md (concise, laser-focused, streamlined)
+
+## Decision Framework
+
+**Priority Order:** User instructions > AGENTS.md compliance > Documentation
+hierarchy > Project patterns > General best practices
+
+**Anti-Scope-Creep Rules:**
+
+- **NEVER implement features without requirement validation**
+- **Always validate implementation decisions against project scope boundaries**
+
+**Anti-Redundancy Rules:**
+
+- **NEVER duplicate information across documents** - reference authoritative sources
+- **Update authoritative document, then remove duplicates elsewhere**
+
+**When to Escalate to AGENT_REQUESTS.md:**
+
+- User instructions conflict with safety/security practices
+- AGENTS.md rules contradict each other
+- Required information completely missing
+- Actions would significantly change project architecture
+
+## Agent Neutrality Requirements
+
+**ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:**
+
+1. **Extract requirements from specified documents ONLY**
+   - Read provided task descriptions or reference materials
+   - Do NOT make assumptions about unstated requirements
+   - Do NOT add functionality not explicitly requested
+
+2. **Request clarification for ambiguous scope**
+   - If task boundaries are unclear, ASK for clarification
+   - If complexity level is not specified, ASK for target complexity
+   - Do NOT assume scope or make architectural decisions without validation
+
+3. **Design to stated requirements exactly**
+   - Match the complexity level requested
+   - Follow "minimal," "streamlined," or "focused" guidance literally
+   - Do NOT over-engineer solutions beyond stated needs
+
+## Compliance Requirements
+
+1. **Command Execution**: Use project make recipes or standard tooling
+2. **Quality Validation**: Run validation before task completion; fix ALL issues
+3. **Coding Style**: Follow existing project patterns and conventions
+4. **Documentation Updates**: Update docs when introducing new patterns
+5. **Testing**: Create tests for new functionality
+6. **Code Standards**: Use absolute imports, add `# Reason:` comments for complex logic
+
+## Quality Thresholds
+
+**Before starting any task, ensure:**
+
+- **Context**: 8/10 - Understand requirements, codebase patterns, dependencies
+- **Clarity**: 7/10 - Clear implementation path and expected outcomes
+- **Alignment**: 8/10 - Follows project patterns and architectural decisions
+- **Success**: 7/10 - Confident in completing task correctly
+
+### Below Threshold Action
+
+Gather more context or escalate to AGENT_REQUESTS.md
+
+## Agent Quick Reference
+
+**Pre-Task:**
+
+- Read AGENTS.md > CONTRIBUTING.md for technical details
+- Verify quality thresholds met
+
+**During Task:**
+
+- Use project commands (document deviations)
+- Follow existing patterns and conventions
+- Update documentation when learning patterns
+
+**Post-Task:**
+
+- Run validation - must pass all checks (code tasks only)
+- Update CHANGELOG.md for non-trivial changes
+- Document new patterns in AGENT_LEARNINGS.md (concise, laser-focused, streamlined)
+- Escalate to AGENT_REQUESTS.md if blocked

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -1,0 +1,14 @@
+---
+title: Agent Learning Documentation
+description: Non-obvious patterns that prevent repeated mistakes across sprints
+---
+
+## Template
+
+- **Context**: When/where this applies
+- **Problem**: What issue this solves
+- **Solution**: Implementation approach
+- **Example**: Working code
+- **References**: Related files
+
+## Learned Patterns

--- a/AGENT_REQUESTS.md
+++ b/AGENT_REQUESTS.md
@@ -1,0 +1,18 @@
+---
+title: Agent Requests to Humans
+description: Escalation protocol and active requests requiring human decision
+---
+
+**Always escalate when:**
+
+- User instructions conflict with safety/security practices
+- Rules contradict each other
+- Required information completely missing
+- Actions would significantly change project architecture
+- Critical dependencies unavailable
+
+**Format:** `- [ ] [PRIORITY] Description` with Context, Problem, Files, Alternatives, Impact
+
+## Active Requests
+
+None.

--- a/LICENSE
+++ b/LICENSE
@@ -48,7 +48,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent
@@ -60,7 +60,7 @@
       designated in writing by the copyright owner as "Not a Contribution."
 
       "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by the Licensor and
+      on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
@@ -106,7 +106,7 @@
       (d) If the Work includes a "NOTICE" text file as part of its
           distribution, then any Derivative Works that You distribute must
           include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding any notices that do not
+          within such NOTICE file, excluding those notices that do not
           pertain to any part of the Derivative Works, in at least one
           of the following places: within a NOTICE text file distributed
           as part of the Derivative Works; within the Source form or
@@ -174,6 +174,17 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
    Copyright 2026 qte77
 


### PR DESCRIPTION
## Summary
Two related chore commits:

### 1. Canonical Apache-2.0 LICENSE (#121)
Fix 3 word-level deviations from ASF canonical text and add APPENDIX section. Text sourced verbatim from https://www.apache.org/licenses/LICENSE-2.0.txt with `Copyright 2026 qte77` substitution.

### 2. Governance files (additive)
Adds root-level AGENTS.md, AGENT_LEARNINGS.md, AGENT_REQUESTS.md — previously absent from the marketplace repo.

## Closes
- #121

Generated with Claude <noreply@anthropic.com>