### PR TITLE
fix(marketplace): sync docs-governance version to 1.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -90,7 +90,7 @@
       "name": "docs-governance",
       "source": "./plugins/docs-governance",
       "description": "Audit and maintain documentation hierarchy and agent governance files",
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     {
       "name": "market-research",


### PR DESCRIPTION
## Summary
- `marketplace.json` listed `docs-governance` at `1.3.1` while `plugins/docs-governance/.claude-plugin/plugin.json` was at `1.3.2`
- Per the `plugin-versioning` rule, both versions MUST match — installed plugins are cached and users won't receive fixes without aligned bumps
- One-line drift fix; no behavioral change

## Test plan
- [ ] CI / version-sync check passes
- [ ] Diff shows only the version field changed for docs-governance

Generated with Claude <noreply@anthropic.com>