### PR TITLE
feat(compound-learning): cross-repo promotion path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,13 +78,13 @@
       "name": "workspace-setup",
       "source": "./plugins/workspace-setup",
       "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
-      "version": "1.3.4"
+      "version": "1.3.6"
     },
     {
       "name": "workspace-sandbox",
       "source": "./plugins/workspace-sandbox",
       "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
-      "version": "1.3.4"
+      "version": "1.3.6"
     },
     {
       "name": "docs-governance",

--- a/.claude/rules/compound-learning.md
+++ b/.claude/rules/compound-learning.md
@@ -10,8 +10,10 @@ Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
 
 1. **1st occurrence** — fix inline, move on
 2. **2nd occurrence** — add to AGENT_LEARNINGS.md (pattern + solution)
-3. **3rd occurrence** — promote to `.claude/rules/` (always-loaded, prevents recurrence)
-4. **Recurring workflow** — extract to `.claude/skills/` (reusable capability)
+3. **3rd occurrence** — promote to a plugin's `rules/` in `claude-code-plugins`,
+   bump the plugin version, and ship via PR. Consumers receive the rule on next
+   plugin update.
+4. **Recurring workflow** — extract to a plugin's `skills/` (reusable capability)
 
 ## When Promoting (step 3)
 
@@ -19,3 +21,15 @@ Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
 - Write the rule as a constraint ("do X", "never Y"), not a narrative
 - Reference the AGENT_LEARNINGS.md entry being promoted
 - Remove or link the original entry to avoid duplication
+- **Choose host plugin**: pick the existing plugin whose domain matches the
+  rule; if none fits, create a minimal plugin (see `plugins/planning/` as
+  scaffold)
+- **Bump version**: update `version` in both
+  `plugins/<name>/.claude-plugin/plugin.json` and
+  `.claude-plugin/marketplace.json` — both must match
+- **Sync shared rules**: if the rule belongs in the cross-cutting
+  `.claude/rules/` set, run `make sync` to propagate copies into
+  `workspace-setup` and `workspace-sandbox`, then bump those plugins' versions
+- **Cross-repo workflow**: when the learning surfaces in a consumer repo
+  (qte77/qte77, polyforge, office-forge, etc.), open the promotion PR against
+  `claude-code-plugins`, not against the consumer

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ sync: sync_rules sync_scripts sync_refs  ## Sync .claude/ SoT into plugin dirs
 sync_rules:  ## Sync rules from .claude/rules/ to plugin copies
 	cp .claude/rules/core-principles.md plugins/workspace-setup/rules/
 	cp .claude/rules/context-management.md plugins/workspace-setup/rules/
+	cp .claude/rules/compound-learning.md plugins/workspace-setup/rules/
+	cp .claude/rules/compound-learning.md plugins/workspace-sandbox/rules/
 	cp .claude/rules/core-principles.md plugins/codebase-tools/skills/researching-codebase/references/
 	cp .claude/rules/context-management.md plugins/codebase-tools/skills/researching-codebase/references/
 	cp .claude/rules/context-management.md plugins/codebase-tools/skills/compacting-context/references/

--- a/plugins/workspace-sandbox/.claude-plugin/plugin.json
+++ b/plugins/workspace-sandbox/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-sandbox",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "sandbox", "read-once"]

--- a/plugins/workspace-sandbox/rules/compound-learning.md
+++ b/plugins/workspace-sandbox/rules/compound-learning.md
@@ -10,8 +10,10 @@ Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
 
 1. **1st occurrence** — fix inline, move on
 2. **2nd occurrence** — add to AGENT_LEARNINGS.md (pattern + solution)
-3. **3rd occurrence** — promote to `.claude/rules/` (always-loaded, prevents recurrence)
-4. **Recurring workflow** — extract to `.claude/skills/` (reusable capability)
+3. **3rd occurrence** — promote to a plugin's `rules/` in `claude-code-plugins`,
+   bump the plugin version, and ship via PR. Consumers receive the rule on next
+   plugin update.
+4. **Recurring workflow** — extract to a plugin's `skills/` (reusable capability)
 
 ## When Promoting (step 3)
 
@@ -19,3 +21,15 @@ Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
 - Write the rule as a constraint ("do X", "never Y"), not a narrative
 - Reference the AGENT_LEARNINGS.md entry being promoted
 - Remove or link the original entry to avoid duplication
+- **Choose host plugin**: pick the existing plugin whose domain matches the
+  rule; if none fits, create a minimal plugin (see `plugins/planning/` as
+  scaffold)
+- **Bump version**: update `version` in both
+  `plugins/<name>/.claude-plugin/plugin.json` and
+  `.claude-plugin/marketplace.json` — both must match
+- **Sync shared rules**: if the rule belongs in the cross-cutting
+  `.claude/rules/` set, run `make sync` to propagate copies into
+  `workspace-setup` and `workspace-sandbox`, then bump those plugins' versions
+- **Cross-repo workflow**: when the learning surfaces in a consumer repo
+  (qte77/qte77, polyforge, office-forge, etc.), open the promotion PR against
+  `claude-code-plugins`, not against the consumer

--- a/plugins/workspace-setup/.claude-plugin/plugin.json
+++ b/plugins/workspace-setup/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-setup",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "governance", "setup", "read-once"]

--- a/plugins/workspace-setup/rules/compound-learning.md
+++ b/plugins/workspace-setup/rules/compound-learning.md
@@ -10,8 +10,10 @@ Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
 
 1. **1st occurrence** — fix inline, move on
 2. **2nd occurrence** — add to AGENT_LEARNINGS.md (pattern + solution)
-3. **3rd occurrence** — promote to `.claude/rules/` (always-loaded, prevents recurrence)
-4. **Recurring workflow** — extract to `.claude/skills/` (reusable capability)
+3. **3rd occurrence** — promote to a plugin's `rules/` in `claude-code-plugins`,
+   bump the plugin version, and ship via PR. Consumers receive the rule on next
+   plugin update.
+4. **Recurring workflow** — extract to a plugin's `skills/` (reusable capability)
 
 ## When Promoting (step 3)
 
@@ -19,3 +21,15 @@ Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
 - Write the rule as a constraint ("do X", "never Y"), not a narrative
 - Reference the AGENT_LEARNINGS.md entry being promoted
 - Remove or link the original entry to avoid duplication
+- **Choose host plugin**: pick the existing plugin whose domain matches the
+  rule; if none fits, create a minimal plugin (see `plugins/planning/` as
+  scaffold)
+- **Bump version**: update `version` in both
+  `plugins/<name>/.claude-plugin/plugin.json` and
+  `.claude-plugin/marketplace.json` — both must match
+- **Sync shared rules**: if the rule belongs in the cross-cutting
+  `.claude/rules/` set, run `make sync` to propagate copies into
+  `workspace-setup` and `workspace-sandbox`, then bump those plugins' versions
+- **Cross-repo workflow**: when the learning surfaces in a consumer repo
+  (qte77/qte77, polyforge, office-forge, etc.), open the promotion PR against
+  `claude-code-plugins`, not against the consumer


### PR DESCRIPTION
## Summary
- Rewrite step 3 of `compound-learning.md` so 3rd-occurrence learnings promote to a plugin's `rules/` in claude-code-plugins (with version bump + PR), not into the consumer's local `.claude/rules/`.
- Adds guidance on host plugin selection, version bumping, sync requirement, and the cross-repo workflow when learnings surface in qte77/qte77, polyforge, or office-forge.
- Sync rewritten rule into `workspace-setup` and `workspace-sandbox` plugins.
- **Makefile fix**: `sync_rules` did not include `compound-learning.md` despite the file existing in plugin copies — silent drift risk. Now included.
- **Version sync fix (incidental)**: `workspace-setup` and `workspace-sandbox` had `plugin.json` at `1.3.5` while marketplace was at `1.3.4`. Both bumped to `1.3.6` in this PR (one bump for the rule change + one absorbing the prior drift).

## Why
This unblocks the agentic team-OS authority chain: claude-code-plugins is canonical for rules; consumer repos (qte77/qte77, polyforge, office-forge) consume via marketplace install. Without this step, agents in consumer repos would promote learnings into local rule trees and they'd never reach other consumers.

## Test plan
- [ ] `make check_sync` passes (compound-learning copies match canonical)
- [ ] `claude plugin validate .` passes for workspace-setup and workspace-sandbox
- [ ] Diff confirms the only changes to `compound-learning.md` are the step 3 rewrite + the new bullets under "When Promoting (step 3)"
- [ ] No other plugins' versions touched

Generated with Claude <noreply@anthropic.com>