### PR TITLE
feat(docs-governance): add governance doc templates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -90,7 +90,7 @@
       "name": "docs-governance",
       "source": "./plugins/docs-governance",
       "description": "Audit and maintain documentation hierarchy and agent governance files",
-      "version": "1.3.1"
+      "version": "1.4.0"
     },
     {
       "name": "market-research",

--- a/plugins/docs-governance/.claude-plugin/plugin.json
+++ b/plugins/docs-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-governance",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Audit and maintain documentation hierarchy and agent governance files",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["docs", "governance", "agents-md", "hierarchy", "audit", "single-source-of-truth"]

--- a/plugins/docs-governance/README.md
+++ b/plugins/docs-governance/README.md
@@ -7,6 +7,25 @@ Audit and maintain documentation hierarchy and agent governance files.
 - **enforcing-doc-hierarchy** — Audit docs against authority chains, detect broken refs, duplicates, scope creep, and chain breaks
 - **maintaining-agents-md** — Keep AGENTS.md, CONTRIBUTING.md, AGENT_LEARNINGS.md, and AGENT_REQUESTS.md in sync with codebase
 
+## Templates
+
+`templates/` ships skeleton governance docs for new projects:
+
+- `AGENTS.md` — agent behavioral rules and decision framework
+- `AGENT_LEARNINGS.md` — pattern discovery log (with promotion path)
+- `AGENT_REQUESTS.md` — escalations to humans
+- `CONTRIBUTING.md` — technical workflows and command reference
+
+**Pattern: copy on init, diverge freely.** Templates provide a consistent
+structural skeleton; project-specific content is filled in per repo. After
+copying, the `maintaining-agents-md` skill keeps structure aligned without
+forcing uniform content.
+
+```bash
+# Copy skeleton into a new project
+cp ~/.claude/plugins/cache/qte77/claude-code-plugins/plugins/docs-governance/templates/*.md ./
+```
+
 ## Install
 
 ```bash

--- a/plugins/docs-governance/templates/AGENTS.md
+++ b/plugins/docs-governance/templates/AGENTS.md
@@ -1,0 +1,75 @@
+# Agent Instructions
+
+**Behavioral rules, compliance requirements, and decision frameworks for AI
+coding agents.** For technical workflows and coding standards, see
+[CONTRIBUTING.md](CONTRIBUTING.md). For project overview, see
+[README.md](README.md).
+
+**External References:**
+
+- @CONTRIBUTING.md — Command reference, testing guidelines, code style patterns
+- @AGENT_REQUESTS.md — Escalation and human collaboration
+- @AGENT_LEARNINGS.md — Pattern discovery and knowledge sharing
+
+## Claude Code Infrastructure
+
+**Rules** (`.claude/rules/`): Session-loaded constraints (always active)
+**Skills** (`.claude/skills/`): Modular capabilities with progressive disclosure
+
+## Core Rules & AI Behavior
+
+<!-- Project-specific rules. Common starting points:
+- Follow SDLC principles: maintainability, modularity, reusability, adaptability
+- Never assume missing context — ask if uncertain
+- Never hallucinate libraries — only use packages verified in dependencies
+- Always confirm file paths exist before referencing
+- Never delete existing code unless explicitly instructed
+- Document new patterns in AGENT_LEARNINGS.md
+- Request human feedback in AGENT_REQUESTS.md
+-->
+
+## Task Tracking Authority
+
+<!-- Define your task tracking hierarchy. Example chain:
+GitHub Issues → per-repo TODO.md → cross-project state → session plans
+-->
+
+## Decision Framework
+
+**Priority Order:** User instructions > AGENTS.md compliance > Documentation
+hierarchy > Project patterns > General best practices
+
+**When to Escalate to AGENT_REQUESTS.md:**
+
+- User instructions conflict with safety/security practices
+- AGENTS.md rules contradict each other
+- Required information completely missing
+- Actions would significantly change project architecture
+
+## Compliance Requirements
+
+<!-- Project-specific quality gates. Common ones:
+1. Command Execution: use project make recipes or standard tooling
+2. Quality Validation: run validation before task completion
+3. Coding Style: follow existing project patterns
+4. Documentation Updates: update docs when introducing patterns
+5. Testing: create tests for new functionality
+-->
+
+## Quality Thresholds
+
+**Before starting any task, ensure:**
+
+- **Context**: 8/10 — Understand requirements, codebase, dependencies
+- **Clarity**: 7/10 — Clear implementation path
+- **Alignment**: 8/10 — Follows project patterns
+- **Success**: 7/10 — Confident in completing correctly
+
+Below threshold: gather more context or escalate.
+
+## Agent Quick Reference
+
+**Pre-task:** Read AGENTS.md → CONTRIBUTING.md, verify thresholds
+**During:** Use project commands, follow patterns, document new ones
+**Post-task:** Run validation, update CHANGELOG.md, document learnings,
+escalate blockers

--- a/plugins/docs-governance/templates/AGENT_LEARNINGS.md
+++ b/plugins/docs-governance/templates/AGENT_LEARNINGS.md
@@ -1,0 +1,27 @@
+# Agent Learnings
+
+Patterns, solutions, and insights discovered during development. Per the
+`compound-learning` rule:
+
+1. **1st occurrence** — fix inline, move on
+2. **2nd occurrence** — add an entry below
+3. **3rd occurrence** — promote to a plugin's `rules/` in `claude-code-plugins`
+   (open a PR there, bump the plugin version)
+4. **Recurring workflow** — extract to a plugin's `skills/`
+
+## Entry Template
+
+```markdown
+### YYYY-MM-DD: <Pattern name>
+
+- **Context**: <when/where this applies>
+- **Problem**: <what issue this solves>
+- **Solution**: <implementation approach>
+- **Validation**: <how to verify it works>
+- **References**: <files, PRs, related entries>
+```
+
+## Active Entries
+
+<!-- Add new patterns here. Prefer concrete file paths and verifiable
+validation steps over abstract advice. -->

--- a/plugins/docs-governance/templates/AGENT_REQUESTS.md
+++ b/plugins/docs-governance/templates/AGENT_REQUESTS.md
@@ -1,0 +1,28 @@
+# Agent Requests to Humans
+
+Escalations, clarifications, and tasks requiring human attention.
+
+## When to Escalate
+
+- User instructions conflict with safety/security practices
+- Rules contradict each other
+- Required information is completely missing from all sources
+- Actions would significantly change project architecture
+- Critical dependencies or libraries are unavailable
+
+## How to Escalate
+
+1. Add a checkbox entry below
+2. Set priority: `[HIGH]`, `[MEDIUM]`, `[LOW]` based on blocking impact
+3. Provide context: paths, error messages, requirements
+4. Suggest alternatives if any exist
+
+## Response Format
+
+- Human responses appear as indented bullets under each item
+- Use `# TODO` for non-urgent items with reminder cadence
+- Mark completed items with `[x]`
+
+## Active Requests
+
+<!-- Add new requests here -->

--- a/plugins/docs-governance/templates/CONTRIBUTING.md
+++ b/plugins/docs-governance/templates/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Technical workflows, coding standards, and command references for this project.
+For behavioral rules and decision frameworks, see [AGENTS.md](AGENTS.md).
+
+## Development Setup
+
+<!-- Project-specific setup commands. Common patterns:
+- `make setup` — install dev dependencies
+- `make setup_claude_code` — install Claude Code CLI
+- Document any required env vars or external services
+-->
+
+## Testing
+
+<!-- Test framework and commands. Examples:
+- `make test_all` — run full test suite
+- `make test_single FILE=<path>` — run a specific test
+- Coverage thresholds and how to view reports
+-->
+
+## Code Style
+
+<!-- Lint and format commands. Examples:
+- `make ruff` (Python) / `make fmt` (Go) / `npm run lint` (TS)
+- Static type checking command
+- Style guide reference (PEP 8, Google style, etc.)
+-->
+
+## Pre-commit Checklist
+
+1. <!-- format/lint command -->
+2. <!-- type-check command -->
+3. <!-- test command -->
+4. Update documentation if patterns changed
+5. Update CHANGELOG.md for non-trivial changes
+
+## Pull Requests
+
+- **Title**: Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`)
+- **Body**: detailed summary of purpose + test plan checklist
+- Link related issues by number
+- Provide screenshots for UI changes
+
+## Documentation
+
+- Apply [markdownlint rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)
+- Use ISO 8601 timestamps (`YYYY-MM-DDTHH:MM:SSZ`)
+- Update AGENTS.md when introducing new agent patterns


### PR DESCRIPTION
## Summary
Ship skeleton governance docs that new projects copy on init and modify per their own context:

- `templates/AGENTS.md` — agent behavioral rules + decision framework
- `templates/AGENT_LEARNINGS.md` — pattern discovery log with promotion path
- `templates/AGENT_REQUESTS.md` — escalations to humans
- `templates/CONTRIBUTING.md` — technical workflows + command reference

**Pattern: copy on init, diverge freely.** Templates provide a consistent structural skeleton; project-specific content is filled in per repo. The existing `maintaining-agents-md` skill keeps structure aligned without forcing uniform content.

## Why
Each project (qte77/qte77, polyforge, office-forge, RAPID-spec-forge, …) reinvents these governance files today. Shipping templates here gives the team-OS a uniform starting point while preserving per-project freedom.

## Versioning
- `plugin.json`: 1.3.2 → 1.4.0 (minor: feature add)
- `marketplace.json`: 1.3.1 → 1.4.0 (also resolves prior 1.3.1 vs 1.3.2 drift)

## Test plan
- [ ] `claude plugin validate .` passes for docs-governance
- [ ] Templates render correctly when copied into a fresh repo
- [ ] README's copy recipe path is accurate against the cache layout

Generated with Claude <noreply@anthropic.com>