### PR TITLE
docs(core-principles): add AHA and Clarity principles

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -24,7 +24,7 @@
       "name": "codebase-tools",
       "source": "./plugins/codebase-tools",
       "description": "Isolated codebase research, quality hardening, and build error resolution via skills and agents",
-      "version": "1.3.0"
+      "version": "1.4.2"
     },
     {
       "name": "cpp-desktop",
@@ -78,7 +78,7 @@
       "name": "workspace-setup",
       "source": "./plugins/workspace-setup",
       "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
-      "version": "1.3.6"
+      "version": "1.3.7"
     },
     {
       "name": "workspace-sandbox",

--- a/.claude/rules/core-principles.md
+++ b/.claude/rules/core-principles.md
@@ -14,6 +14,10 @@ user value, clarity, and usability.
 
 **DRY (Don't Repeat Yourself)** - Single source of truth. Reference, don't duplicate.
 
+**AHA (Avoid Hasty Abstractions)** - Prefer duplication over the wrong abstraction.
+Wait until the pattern is stable before extracting. A bad abstraction costs more
+than repeated code.
+
 **YAGNI (You Aren't Gonna Need It)** - Implement only what's requested. No
 speculative features.
 
@@ -31,6 +35,10 @@ speculative features.
 
 **Rigor and Sufficiency** - Research enough to decide confidently. No more, no less.
 
+**Clarity** - Communicate so the reader can act without re-reading. Name things
+for what they are; state decisions and reasons plainly; prefer concrete examples
+over abstract framing.
+
 **High-Impact Quick Wins** - Prioritize must-do tasks. Ship fast, iterate.
 
 **Actionable and Concrete** - Specific deliverables. Measurable outcomes.
@@ -45,6 +53,7 @@ speculative features.
 - [ ] Do I actually need this?
 - [ ] Am I touching only relevant code?
 - [ ] What's the root cause I'm solving?
+- [ ] Is this clear to a reader who lacks my context?
 
 ## Post-Task Review
 

--- a/plugins/codebase-tools/.claude-plugin/plugin.json
+++ b/plugins/codebase-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-tools",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Isolated codebase research, quality hardening, and build error resolution via skills and agents",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["research", "codebase", "exploration", "hardening", "lint", "review", "build-errors", "typescript"]

--- a/plugins/codebase-tools/skills/researching-codebase/references/core-principles.md
+++ b/plugins/codebase-tools/skills/researching-codebase/references/core-principles.md
@@ -14,6 +14,10 @@ user value, clarity, and usability.
 
 **DRY (Don't Repeat Yourself)** - Single source of truth. Reference, don't duplicate.
 
+**AHA (Avoid Hasty Abstractions)** - Prefer duplication over the wrong abstraction.
+Wait until the pattern is stable before extracting. A bad abstraction costs more
+than repeated code.
+
 **YAGNI (You Aren't Gonna Need It)** - Implement only what's requested. No
 speculative features.
 
@@ -31,6 +35,10 @@ speculative features.
 
 **Rigor and Sufficiency** - Research enough to decide confidently. No more, no less.
 
+**Clarity** - Communicate so the reader can act without re-reading. Name things
+for what they are; state decisions and reasons plainly; prefer concrete examples
+over abstract framing.
+
 **High-Impact Quick Wins** - Prioritize must-do tasks. Ship fast, iterate.
 
 **Actionable and Concrete** - Specific deliverables. Measurable outcomes.
@@ -45,6 +53,7 @@ speculative features.
 - [ ] Do I actually need this?
 - [ ] Am I touching only relevant code?
 - [ ] What's the root cause I'm solving?
+- [ ] Is this clear to a reader who lacks my context?
 
 ## Post-Task Review
 

--- a/plugins/workspace-setup/.claude-plugin/plugin.json
+++ b/plugins/workspace-setup/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-setup",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "governance", "setup", "read-once"]

--- a/plugins/workspace-setup/rules/core-principles.md
+++ b/plugins/workspace-setup/rules/core-principles.md
@@ -14,6 +14,10 @@ user value, clarity, and usability.
 
 **DRY (Don't Repeat Yourself)** - Single source of truth. Reference, don't duplicate.
 
+**AHA (Avoid Hasty Abstractions)** - Prefer duplication over the wrong abstraction.
+Wait until the pattern is stable before extracting. A bad abstraction costs more
+than repeated code.
+
 **YAGNI (You Aren't Gonna Need It)** - Implement only what's requested. No
 speculative features.
 
@@ -31,6 +35,10 @@ speculative features.
 
 **Rigor and Sufficiency** - Research enough to decide confidently. No more, no less.
 
+**Clarity** - Communicate so the reader can act without re-reading. Name things
+for what they are; state decisions and reasons plainly; prefer concrete examples
+over abstract framing.
+
 **High-Impact Quick Wins** - Prioritize must-do tasks. Ship fast, iterate.
 
 **Actionable and Concrete** - Specific deliverables. Measurable outcomes.
@@ -45,6 +53,7 @@ speculative features.
 - [ ] Do I actually need this?
 - [ ] Am I touching only relevant code?
 - [ ] What's the root cause I'm solving?
+- [ ] Is this clear to a reader who lacks my context?
 
 ## Post-Task Review
 


### PR DESCRIPTION
# Summary

Adds two principles to `core-principles.md`:

- **AHA (Avoid Hasty Abstractions)** — under *Code Quality Principles*, balancing DRY. Prefer duplication over the wrong abstraction until the pattern is stable.
- **Clarity** — under *Decision Principles*, alongside *Rigor and Sufficiency*. Communicate so the reader can act without re-reading.

Plus one matching pre-task checklist item: *"Is this clear to a reader who lacks my context?"*

Synced across all three `core-principles.md` copies (`.claude/rules/` SoT and the two plugin-synced copies under `workspace-setup` and `codebase-tools/researching-codebase/references/`) per `make sync` convention.

Closes N/A

## Type of Change

- [x] `docs` — documentation only

Note: ships as `docs(core-principles)` because the change is to a rules document, not plugin code. Two plugin versions still bump to ensure the synced copies propagate to installed plugins (see `plugin-versioning.md`).

## Self-Review

- [x] I have reviewed my own diff and removed debug/dead code
- [x] Commit messages follow `.gitmessage` format

## Testing

- [x] All three `core-principles.md` copies are byte-identical (verified via `diff`)
- [x] `workspace-setup` and `codebase-tools` `plugin.json` versions match `marketplace.json`
- [ ] `make validate` (not run locally — please verify in CI)
- [ ] `make check_sync` (not run locally — please verify in CI)

## Documentation

- [ ] CHANGELOG entry — defer to a batch update
- [ ] LEARNINGS.md — N/A (no new pattern)
- [ ] Plugin README — N/A (rule wording change)

## Side note: pre-existing version drift discovered

While reconciling the `codebase-tools` version bump for this PR, the `marketplace.json` entry was found at `1.3.0` while `plugin.json` was at `1.4.1` (a much older drift). Reset both to `1.4.2` here. A follow-up PR adds CI to catch this class of drift globally — opening separately so this PR stays scoped to the principles change.

🤖 Generated with Claude <noreply@anthropic.com>