### PR TITLE
fix(marketplace): reconcile version drift from #122 merge artifact

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,13 +12,13 @@
       "name": "python-dev",
       "source": "./plugins/python-dev",
       "description": "Python implementation, testing, code review skills, and scaffold adapter for Ralph loop",
-      "version": "2.1.2"
+      "version": "2.1.3"
     },
     {
       "name": "commit-helper",
       "source": "./plugins/commit-helper",
       "description": "Generate conventional commit messages and pull requests with approval workflow",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "codebase-tools",
@@ -30,49 +30,49 @@
       "name": "cpp-desktop",
       "source": "./plugins/cpp-desktop",
       "description": "C++ desktop GUI development with wxWidgets, GTK, Qt \u2014 implement, review, analyze",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "cc-meta",
       "source": "./plugins/cc-meta",
       "description": "Claude Code meta-skills for cross-project synthesis, context compaction, session intelligence, and memory seed template",
-      "version": "1.15.0"
+      "version": "1.15.1"
     },
     {
       "name": "backend-design",
       "source": "./plugins/backend-design",
       "description": "Backend system architecture and API design skills",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "mas-design",
       "source": "./plugins/mas-design",
       "description": "Multi-agent system plugin design and OWASP MAESTRO security framework",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "website-audit",
       "source": "./plugins/website-audit",
       "description": "Website design research, usability audit, and WCAG accessibility audit skills",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "docs-generator",
       "source": "./plugins/docs-generator",
       "description": "Document generation for writeups, tech specs (ADR/RFC/design docs), and reports with pandoc PDF output",
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     {
       "name": "ralph",
       "source": "./plugins/ralph",
       "description": "PRD-to-JSON conversion, interactive user story builder, and PRD generation for the Ralph loop",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "embedded-dev",
       "source": "./plugins/embedded-dev",
       "description": "Embedded firmware development with CE/FCC compliance, ESP-IDF/PlatformIO, requirement traceability, and KiCad PCB auditing",
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     {
       "name": "workspace-setup",
@@ -96,19 +96,19 @@
       "name": "market-research",
       "source": "./plugins/market-research",
       "description": "GTM market research pipeline with teams mode parallel dispatch and configurable 2x2 strategy matrix",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "rust-dev",
       "source": "./plugins/rust-dev",
       "description": "Rust implementation, testing, and code review skills, deploys cargo permissions via SessionStart hook",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "go-dev",
       "source": "./plugins/go-dev",
       "description": "Go implementation, testing, and code review skills, deploys go tool permissions via SessionStart hook",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "gha-dev",
@@ -120,13 +120,13 @@
       "name": "tdd-core",
       "source": "./plugins/tdd-core",
       "description": "Language-agnostic TDD methodology: Red-Green-Refactor, Arrange-Act-Assert, testing strategy",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "rag-core",
       "source": "./plugins/rag-core",
       "description": "Document indexing and hybrid retrieval with heading-boundary chunking, FAISS vector store, and PageIndex tree filtering",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "cc-voice",
@@ -141,7 +141,7 @@
       "name": "typescript-dev",
       "source": "./plugins/typescript-dev",
       "description": "TypeScript implementation, testing, and code review skills, deploys npm/vitest permissions via SessionStart hook",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "simplify",
@@ -153,7 +153,7 @@
       "name": "security-audit",
       "source": "./plugins/security-audit",
       "description": "Code security audit \u2014 OWASP Top 10, dependency vulnerabilities, secrets detection",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "makefile-core",
@@ -171,7 +171,7 @@
       "name": "planning",
       "source": "./plugins/planning",
       "description": "Feature and refactor planning agents \u2014 detailed implementation plans with phased steps, dependencies, risks, and success criteria",
-      "version": "1.0.0"
+      "version": "1.0.1"
     }
   ]
 }

--- a/plugins/makefile-core/.claude-plugin/plugin.json
+++ b/plugins/makefile-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "makefile-core",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Skills and linting for consistent, rigorous Makefiles across projects — auto-detects project type, extensible via scaffold-*.md references",
   "author": {
     "name": "Claude Code Utils Contributors"


### PR DESCRIPTION
# Summary

Reconciles 19 plugin-version drifts between `plugins/<name>/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`. All drifts trace to a single root cause: **PR #122 silently reverted marketplace.json's version entries** — likely a rebase conflict resolution that selected the pre-#120 state of the file.

Per-plugin classification (no uniform rule — versions are independent):

- **18 plugins**: `plugin.json` reflects actual shipped state (#120 bump retained); marketplace.json was rolled back by #122 → bump marketplace.json entry to match plugin.json.
- **makefile-core**: `marketplace.json` correctly holds `1.2.0` (set by #116's language-recipe scaffold feature); `plugin.json` was overwritten to `1.1.1` by #120 and never re-bumped → bump plugin.json from `1.1.1` to `1.2.0`.

Zero functional change.

Closes N/A

## Type of Change

- [x] `fix` — bug fix (metadata reconciliation)

## Self-Review

- [x] I have reviewed my own diff and removed debug/dead code
- [x] Commit message follows `.gitmessage` format
- [x] Per-plugin classification verified against git history (single root-cause traceback)

## Testing

- [x] Local audit: after this PR + #132 land, all 25 local-source plugins have `plugin.json` == `marketplace.json` version
- [x] Drift audit script (proposed in #133) returns `errors=0` when applied to this branch + #132 merged
- [ ] `make validate` (no plugin structure change)
- [ ] `make test_install` (no functional change)

## Documentation

- [ ] CHANGELOG entry — defer to a batch update
- [ ] LEARNINGS.md — worth an entry: *"Rebases that touch marketplace.json must be reviewed line-by-line; CI didn't catch the silent revert because no plugin paths changed in #122 beyond gha-dev's own."* Adding separately.
- [ ] Plugin README — N/A

## Related PRs

- **#132** (`docs(core-principles): add AHA and Clarity principles`) — fixes the 20th drift (`codebase-tools`) as a side-effect.
- **#133** (`ci(check-plugin-versions): audit all plugins for version drift`) — adds CI to catch this class of drift in future PRs. Will pass once both this PR and #132 land.

Suggested merge order: this PR → #132 → #133.

## Out of scope

- The marketplace `name` field still reads `qte77-claude-code-utils` (also reverted by #122 alongside the rename to `claude-code-plugins`). Same root cause but separable; will follow up.

🤖 Generated with Claude <noreply@anthropic.com>