### PR TITLE
feat(statusline): opt-in world-clock via CC_WORLD_CLOCK

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,13 +78,13 @@
       "name": "workspace-setup",
       "source": "./plugins/workspace-setup",
       "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
-      "version": "1.3.7"
+      "version": "1.3.8"
     },
     {
       "name": "workspace-sandbox",
       "source": "./plugins/workspace-sandbox",
       "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
-      "version": "1.3.6"
+      "version": "1.3.7"
     },
     {
       "name": "docs-governance",

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -1,4 +1,43 @@
 #!/bin/bash
+#
+# World clock (opt-in)
+# --------------------
+# Local time is always shown. To append additional zones, set CC_WORLD_CLOCK.
+# Unset = off (default). Empty = off.
+#
+# Zones render in the order you list them. Suggested convention:
+# order east-to-west (sunrise order) so time decreases left-to-right.
+#
+# Suggested default (copy to your shell rc):
+#   export CC_WORLD_CLOCK="Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles"
+#
+# Other examples:
+#   export CC_WORLD_CLOCK="Asia/Tokyo,Asia/Singapore,UTC"
+#
+# Use IANA Region/City names (system tzdata under /usr/share/zoneinfo).
+# DST is handled automatically. Invalid zones render as "?<name>" so typos
+# are visible at a glance. On Alpine, install tzdata first: apk add tzdata.
+#
+# When set, world-clock zones render on their own line below the main
+# statusline. If your local zone is in the list it will appear twice —
+# omit it from CC_WORLD_CLOCK to avoid duplication.
+#
+# Curated shortlist (full list: find /usr/share/zoneinfo -type f):
+#   UTC anchor : UTC
+#   Americas   : America/Los_Angeles America/Denver America/Chicago
+#                America/New_York America/Toronto America/Mexico_City
+#                America/Sao_Paulo America/Argentina/Buenos_Aires
+#   Europe     : Europe/London Europe/Dublin Europe/Lisbon Europe/Paris
+#                Europe/Berlin Europe/Madrid Europe/Rome Europe/Amsterdam
+#                Europe/Zurich Europe/Stockholm Europe/Warsaw Europe/Athens
+#                Europe/Istanbul Europe/Moscow
+#   Africa/ME  : Africa/Lagos Africa/Cairo Africa/Johannesburg
+#                Asia/Jerusalem Asia/Dubai Asia/Riyadh
+#   Asia       : Asia/Karachi Asia/Kolkata Asia/Dhaka Asia/Bangkok
+#                Asia/Jakarta Asia/Singapore Asia/Hong_Kong Asia/Shanghai
+#                Asia/Taipei Asia/Seoul Asia/Tokyo
+#   Oceania    : Australia/Perth Australia/Adelaide Australia/Sydney
+#                Pacific/Auckland Pacific/Honolulu
 
 input=$(cat)
 
@@ -59,9 +98,28 @@ fi
 user=$(whoami)
 time=$(date +%H:%M:%S)
 
+# Build world-clock line (rendered on its own line when CC_WORLD_CLOCK is set).
+# If your local zone is in the list (e.g. Europe/Paris while in Paris) it will
+# appear twice — omit it from CC_WORLD_CLOCK to avoid duplication.
+clocks=""
+if [ -n "$CC_WORLD_CLOCK" ]; then
+    IFS=',' read -ra _zones <<< "$CC_WORLD_CLOCK"
+    for tz in "${_zones[@]}"; do
+        if [ -f "/usr/share/zoneinfo/$tz" ]; then
+            clocks+=" ${tz##*/}:$(TZ="$tz" date +%H:%M)"
+        else
+            clocks+=" ?${tz}"
+        fi
+    done
+fi
+
 if git rev-parse --git-dir >/dev/null 2>&1; then
     branch=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
     else branch=""
 fi
 
 printf "\\033[0;31magent:%s \\033[0;33mmodel:%s \\033[2mver:%s \\033[0;34mcost:%s \\033[0;36mdur:%s\\n\\033[0;32mlines:%s \\033[2mtokens(i/o):%s ${ctx_color}ctx(free):%s\\033[0m \\033[0;31m>200k:%s\\033[0m\\n\\033[2mdir:%s \\033[0;36mbranch:%s \\033[0;32muser:%s \\033[0;35mtime:%s\\033[0m" "$agent" "$model" "$version" "$cost" "$duration" "$lines_changed" "$tokens" "$remaining" "$exc_context" "$(basename "$cwd")" "$branch" "$user" "$time"
+
+if [ -n "$clocks" ]; then
+    printf "\\n\\033[0;35mclocks:%s\\033[0m" "$clocks"
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **docs-governance**: `enforcing-doc-hierarchy` skill rewritten — generic, KISS-oriented; no longer coupled to specific project layouts (#64)
 - **docs-governance**: `enforcing-doc-hierarchy` description tightened from 295 → 179 chars per skill-authoring convention (#109)
 - **workspace-setup / workspace-sandbox**: `statusline.sh` deduplicated via symlinks (#81)
+- **workspace-setup / workspace-sandbox**: `statusline.sh` world-clock — opt-in via `CC_WORLD_CLOCK` env var (comma-separated IANA zones, east-to-west sunrise order recommended), renders on dedicated 4th line, invalid zones marked `?<name>`. workspace-setup 1.3.7 → 1.3.8, workspace-sandbox 1.3.6 → 1.3.7
 - **python-dev**: Removed BDD, enforce TDD-only testing; reference file `bdd-best-practices.md` renamed to `bdd-best-practices-future-use.md` (parked) (#94)
 - **cc-meta**: Plugin version 1.4.0 → 1.15.0 across seven successive feature merges (#91, #92, #93, #96, #97, #98, #99)
 - **cc-meta**: `synthesizing-cc-bigpicture` SKILL.md 195 → 128 lines — extracted Two Reasoning Axes, CC Data Sources, Output Format into `references/reasoning-modes.md`, `references/cc-data-sources.md`, `references/output-template.md` (#108)

--- a/plugins/workspace-sandbox/.claude-plugin/plugin.json
+++ b/plugins/workspace-sandbox/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-sandbox",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "sandbox", "read-once"]

--- a/plugins/workspace-sandbox/README.md
+++ b/plugins/workspace-sandbox/README.md
@@ -9,7 +9,7 @@ network exfiltration protection.
 ## Deployed files
 
 - **rules/*.md** → `.claude/rules/` — core principles, context management
-- **scripts/statusline.sh** → `.claude/scripts/` — status line display
+- **scripts/statusline.sh** → `.claude/scripts/` — status line display. World clock off by default. Opt in with `CC_WORLD_CLOCK="Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles"` (east-to-west / sunrise order) or any IANA zones you prefer; zones render on a dedicated line below the main statusline. Invalid zones show as `?<name>`. See the comment block at the top of `.claude/scripts/statusline.sh` for the curated shortlist and usage notes.
 - **settings/.gitignore** → `.gitignore` — hides bwrap phantom files from git status
 - **settings/settings-sandbox.json** → `.claude/settings.json` — eased sandbox, permissions, env vars
 - **governance/*.md** → `AGENTS.md`, `AGENT_LEARNINGS.md`, `AGENT_REQUESTS.md` — agent governance

--- a/plugins/workspace-setup/.claude-plugin/plugin.json
+++ b/plugins/workspace-setup/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-setup",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "governance", "setup", "read-once"]

--- a/plugins/workspace-setup/README.md
+++ b/plugins/workspace-setup/README.md
@@ -7,7 +7,7 @@ Self-contained — all CC-specific files bundled in the plugin, no external depe
 ## Deployed files
 
 - **rules/*.md** → `.claude/rules/` — core principles, context management
-- **scripts/statusline.sh** → `.claude/scripts/` — status line display
+- **scripts/statusline.sh** → `.claude/scripts/` — status line display. World clock off by default. Opt in with `CC_WORLD_CLOCK="Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles"` (east-to-west / sunrise order) or any IANA zones you prefer; zones render on a dedicated line below the main statusline. Invalid zones show as `?<name>`. See the comment block at the top of `.claude/scripts/statusline.sh` for the curated shortlist and usage notes.
 - **settings/settings-base.json** → `.claude/settings.json` — lightweight defaults (statusline, context7, attribution)
 - **governance/AGENTS.md** → `AGENTS.md` — agent behavioral rules and decision framework
 - **governance/AGENT_LEARNINGS.md** → `AGENT_LEARNINGS.md` — pattern discovery template


### PR DESCRIPTION
# Summary

Adds an opt-in world-clock display to the workspace-setup / workspace-sandbox statusline. Users who set the `CC_WORLD_CLOCK` env var (comma-separated IANA zones) see a dedicated 4th line below the main statusline showing each zone's current time. Off when unset — zero behavior change for existing users.

Closes N/A

## Type of Change

- [x] `feat` — new feature (plugin, skill, hook, command)
- [x] `docs` — documentation only

(`feat` for the script change, `docs` for the README updates — split into two commits.)

## Self-Review

- [x] I have reviewed my own diff and removed debug/dead code
- [x] Commit messages follow `.gitmessage` format: `type(scope): description`

## Testing

- [x] `make validate` passes (plugin structure + JSON syntax)
- [ ] `make test_install` — not run locally; CI to verify
- [x] `make check_sync` passes (statusline.sh symlinks intact, all copies in sync)

Manual verification:

```bash
export CC_WORLD_CLOCK="Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles"
echo '{}' | bash .claude/scripts/statusline.sh
```

Renders local time on line 3 and the six zones on a new 4th line. Invalid zones (e.g. `FakeZone/Nowhere`) render as `?FakeZone/Nowhere`.

## Documentation

- [x] `CHANGELOG.md` updated under `## [Unreleased]` → `### Changed` → `Refactors and docs (#38-#112)` (alongside existing statusline entries)
- [ ] `LEARNINGS.md` — not applicable (no new gotcha)
- [x] Plugin README updated for both workspace-setup and workspace-sandbox

## Version bumps (per plugin-versioning rule)

| Plugin             | Old    | New    |
|--------------------|--------|--------|
| workspace-setup    | 1.3.7  | 1.3.8  |
| workspace-sandbox  | 1.3.6  | 1.3.7  |

Bumped in both `plugin.json` and `marketplace.json`.

🤖 Generated with Claude <noreply@anthropic.com>