### PR TITLE
feat(statusline): live-toggle world-clock via ~/.claude/world-clock

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,13 +78,13 @@
       "name": "workspace-setup",
       "source": "./plugins/workspace-setup",
       "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
-      "version": "1.3.8"
+      "version": "1.3.9"
     },
     {
       "name": "workspace-sandbox",
       "source": "./plugins/workspace-sandbox",
       "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
-      "version": "1.3.7"
+      "version": "1.3.8"
     },
     {
       "name": "docs-governance",

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -2,14 +2,28 @@
 #
 # World clock (opt-in)
 # --------------------
-# Local time is always shown. To append additional zones, set CC_WORLD_CLOCK.
-# Unset = off (default). Empty = off.
+# Local time is always shown. To append additional zones, configure either:
+#
+#   (1) CC_WORLD_CLOCK env var — set in your shell rc; persistent across
+#       sessions. Requires CC restart to change (env is fixed at launch).
+#
+#   (2) ~/.claude/world-clock file — single line of comma-separated zones.
+#       Live toggle: edit/delete the file and the next prompt render picks
+#       it up, no CC restart needed. Use when you want to flip clocks on/off
+#       inside an active session.
+#
+# Precedence: env var wins; file is the fallback. Unset env + missing/empty
+# file = off (default).
 #
 # Zones render in the order you list them. Suggested convention:
 # order east-to-west (sunrise order) so time decreases left-to-right.
 #
-# Suggested default (copy to your shell rc):
+# Suggested default (env-var form, copy to your shell rc):
 #   export CC_WORLD_CLOCK="Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles"
+#
+# Live-toggle form:
+#   echo "Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles" > ~/.claude/world-clock
+#   rm ~/.claude/world-clock                                                                # turn off
 #
 # Other examples:
 #   export CC_WORLD_CLOCK="Asia/Tokyo,Asia/Singapore,UTC"
@@ -98,12 +112,15 @@ fi
 user=$(whoami)
 time=$(date +%H:%M:%S)
 
-# Build world-clock line (rendered on its own line when CC_WORLD_CLOCK is set).
+# Build world-clock line. Source order:
+#   1. $CC_WORLD_CLOCK env var (set in shell rc, requires CC restart to change)
+#   2. ~/.claude/world-clock file content (live toggle — picked up on next render)
 # If your local zone is in the list (e.g. Europe/Paris while in Paris) it will
-# appear twice — omit it from CC_WORLD_CLOCK to avoid duplication.
+# appear twice — omit it to avoid duplication.
 clocks=""
-if [ -n "$CC_WORLD_CLOCK" ]; then
-    IFS=',' read -ra _zones <<< "$CC_WORLD_CLOCK"
+zones_spec="${CC_WORLD_CLOCK:-$(cat "$HOME/.claude/world-clock" 2>/dev/null)}"
+if [ -n "$zones_spec" ]; then
+    IFS=',' read -ra _zones <<< "$zones_spec"
     for tz in "${_zones[@]}"; do
         if [ -f "/usr/share/zoneinfo/$tz" ]; then
             clocks+=" ${tz##*/}:$(TZ="$tz" date +%H:%M)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **docs-governance**: `enforcing-doc-hierarchy` description tightened from 295 → 179 chars per skill-authoring convention (#109)
 - **workspace-setup / workspace-sandbox**: `statusline.sh` deduplicated via symlinks (#81)
 - **workspace-setup / workspace-sandbox**: `statusline.sh` world-clock — opt-in via `CC_WORLD_CLOCK` env var (comma-separated IANA zones, east-to-west sunrise order recommended), renders on dedicated 4th line, invalid zones marked `?<name>`. workspace-setup 1.3.7 → 1.3.8, workspace-sandbox 1.3.6 → 1.3.7
+- **workspace-setup / workspace-sandbox**: `statusline.sh` world-clock live toggle — `~/.claude/world-clock` file fallback for in-session changes (env var still wins; file picked up on next render, no CC restart needed). workspace-setup 1.3.8 → 1.3.9, workspace-sandbox 1.3.7 → 1.3.8
 - **python-dev**: Removed BDD, enforce TDD-only testing; reference file `bdd-best-practices.md` renamed to `bdd-best-practices-future-use.md` (parked) (#94)
 - **cc-meta**: Plugin version 1.4.0 → 1.15.0 across seven successive feature merges (#91, #92, #93, #96, #97, #98, #99)
 - **cc-meta**: `synthesizing-cc-bigpicture` SKILL.md 195 → 128 lines — extracted Two Reasoning Axes, CC Data Sources, Output Format into `references/reasoning-modes.md`, `references/cc-data-sources.md`, `references/output-template.md` (#108)

--- a/plugins/workspace-sandbox/.claude-plugin/plugin.json
+++ b/plugins/workspace-sandbox/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-sandbox",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Deploys workspace rules, statusline script, eased sandbox settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "sandbox", "read-once"]

--- a/plugins/workspace-sandbox/README.md
+++ b/plugins/workspace-sandbox/README.md
@@ -9,7 +9,7 @@ network exfiltration protection.
 ## Deployed files
 
 - **rules/*.md** → `.claude/rules/` — core principles, context management
-- **scripts/statusline.sh** → `.claude/scripts/` — status line display. World clock off by default. Opt in with `CC_WORLD_CLOCK="Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles"` (east-to-west / sunrise order) or any IANA zones you prefer; zones render on a dedicated line below the main statusline. Invalid zones show as `?<name>`. See the comment block at the top of `.claude/scripts/statusline.sh` for the curated shortlist and usage notes.
+- **scripts/statusline.sh** → `.claude/scripts/` — status line display. World clock off by default. Two ways to opt in: (1) **persistent** — set `CC_WORLD_CLOCK="Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles"` in your shell rc (needs CC restart to change); (2) **live toggle** — write the same comma-separated zone list to `~/.claude/world-clock` (next prompt render picks it up; `rm` the file to turn off). Env var wins over file. Use east-to-west / sunrise order or any IANA zones you prefer. Zones render on a dedicated line below the main statusline; invalid zones show as `?<name>`. See the comment block at the top of `.claude/scripts/statusline.sh` for the curated shortlist and usage notes.
 - **settings/.gitignore** → `.gitignore` — hides bwrap phantom files from git status
 - **settings/settings-sandbox.json** → `.claude/settings.json` — eased sandbox, permissions, env vars
 - **governance/*.md** → `AGENTS.md`, `AGENT_LEARNINGS.md`, `AGENT_REQUESTS.md` — agent governance

--- a/plugins/workspace-setup/.claude-plugin/plugin.json
+++ b/plugins/workspace-setup/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-setup",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "governance", "setup", "read-once"]

--- a/plugins/workspace-setup/README.md
+++ b/plugins/workspace-setup/README.md
@@ -7,7 +7,7 @@ Self-contained — all CC-specific files bundled in the plugin, no external depe
 ## Deployed files
 
 - **rules/*.md** → `.claude/rules/` — core principles, context management
-- **scripts/statusline.sh** → `.claude/scripts/` — status line display. World clock off by default. Opt in with `CC_WORLD_CLOCK="Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles"` (east-to-west / sunrise order) or any IANA zones you prefer; zones render on a dedicated line below the main statusline. Invalid zones show as `?<name>`. See the comment block at the top of `.claude/scripts/statusline.sh` for the curated shortlist and usage notes.
+- **scripts/statusline.sh** → `.claude/scripts/` — status line display. World clock off by default. Two ways to opt in: (1) **persistent** — set `CC_WORLD_CLOCK="Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles"` in your shell rc (needs CC restart to change); (2) **live toggle** — write the same comma-separated zone list to `~/.claude/world-clock` (next prompt render picks it up; `rm` the file to turn off). Env var wins over file. Use east-to-west / sunrise order or any IANA zones you prefer. Zones render on a dedicated line below the main statusline; invalid zones show as `?<name>`. See the comment block at the top of `.claude/scripts/statusline.sh` for the curated shortlist and usage notes.
 - **settings/settings-base.json** → `.claude/settings.json` — lightweight defaults (statusline, context7, attribution)
 - **governance/AGENTS.md** → `AGENTS.md` — agent behavioral rules and decision framework
 - **governance/AGENT_LEARNINGS.md** → `AGENT_LEARNINGS.md` — pattern discovery template


### PR DESCRIPTION
# Summary

Follow-up to #136. The `CC_WORLD_CLOCK` env var is fixed at CC launch — flipping it inside an active session has no effect. This PR adds a **file-based fallback** at `~/.claude/world-clock` that the statusline reads on every prompt render: write the file to enable, `rm` to disable, no CC restart needed.

Precedence: env var wins, file is the fallback. Unset env + missing file = off (default behavior unchanged for users who haven't opted in).

Closes N/A

## Type of Change

- [x] `feat` — new feature (plugin, skill, hook, command)
- [x] `docs` — documentation only

(`feat` for the script change, `docs` for the README updates — split into two commits.)

## Self-Review

- [x] I have reviewed my own diff and removed debug/dead code
- [x] Commit messages follow `.gitmessage` format

## Testing

- [x] `make validate` passes
- [ ] `make test_install` — not run locally; CI to verify
- [x] `make check_sync` passes (statusline.sh symlinks intact)

Manual verification (with HOME override to keep the live env clean):

```bash
mkdir -p /tmp/.claude
echo "Asia/Tokyo,Europe/Paris" > /tmp/.claude/world-clock
unset CC_WORLD_CLOCK
HOME=/tmp echo '{}' | bash .claude/scripts/statusline.sh
# → renders "clocks: Tokyo:01:31 Paris:18:31" on a 4th line
```

Also confirmed env var still wins when both are set, and removing the file restores the off state.

## Documentation

- [x] `CHANGELOG.md` updated under `## [Unreleased]` → `### Changed` → `Refactors and docs`
- [ ] `LEARNINGS.md` — not applicable
- [x] Plugin READMEs updated for both workspace-setup and workspace-sandbox
- [x] Help comment block at the top of `.claude/scripts/statusline.sh` updated to document both opt-in paths and their precedence

## Version bumps (per plugin-versioning rule)

| Plugin             | Old    | New    |
|--------------------|--------|--------|
| workspace-setup    | 1.3.8  | 1.3.9  |
| workspace-sandbox  | 1.3.7  | 1.3.8  |

Bumped in both `plugin.json` and `marketplace.json`.

🤖 Generated with Claude <noreply@anthropic.com>