### PR TITLE
chore(gitignore): exclude MEMORY.md auto-memory seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 temp/
+
+# Auto-memory seed deployed by cc-meta's SessionStart hook — per-contributor,
+# not part of the repo's tracked tree.
+MEMORY.md


### PR DESCRIPTION
# Summary

The cc-meta SessionStart hook deploys a per-contributor `MEMORY.md` seed into every project root. It's contributor-specific (each person builds their own auto-memory entries against it) and not part of the repo's tracked tree. Add it to `.gitignore` so it stops cluttering `git status` across sessions.

Closes N/A

## Type of Change

- [x] `chore` — tooling, config, maintenance

## Self-Review

- [x] I have reviewed my own diff and removed debug/dead code
- [x] Commit message follows `.gitmessage` format

## Testing

- [x] `make validate` passes
- [ ] `make test_install` — N/A (no plugin file changes)
- [x] `git status` no longer reports the seed file as untracked
- No plugin version bumps needed (root `.gitignore`, not under `plugins/`)

## Documentation

- [ ] `CHANGELOG.md` — optional for `.gitignore` housekeeping; skipped to keep noise low. Happy to add an entry under `Changed` if maintainers prefer.
- [ ] `LEARNINGS.md` — N/A
- [ ] Plugin README — N/A

🤖 Generated with Claude <noreply@anthropic.com>