### PR TITLE
chore(makefile): fix compacting-context sync path (cc-meta, not codebase-tools)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ sync_rules:  ## Sync rules from .claude/rules/ to plugin copies
 	cp .claude/rules/compound-learning.md plugins/workspace-sandbox/rules/
 	cp .claude/rules/core-principles.md plugins/codebase-tools/skills/researching-codebase/references/
 	cp .claude/rules/context-management.md plugins/codebase-tools/skills/researching-codebase/references/
-	cp .claude/rules/context-management.md plugins/codebase-tools/skills/compacting-context/references/
+	cp .claude/rules/context-management.md plugins/cc-meta/skills/compacting-context/references/
 
 sync_scripts:  ## Sync scripts from .claude/scripts/ to plugin copies (statusline.sh uses symlinks)
 	cp .claude/scripts/read-once/hook.sh plugins/workspace-setup/scripts/read-once/
@@ -56,7 +56,7 @@ check_sync:  ## Verify all copies are in sync with .claude/ SoT
 	@diff -q .claude/rules/context-management.md plugins/workspace-setup/rules/context-management.md
 	@diff -q .claude/rules/core-principles.md plugins/codebase-tools/skills/researching-codebase/references/core-principles.md
 	@diff -q .claude/rules/context-management.md plugins/codebase-tools/skills/researching-codebase/references/context-management.md
-	@diff -q .claude/rules/context-management.md plugins/codebase-tools/skills/compacting-context/references/context-management.md
+	@diff -q .claude/rules/context-management.md plugins/cc-meta/skills/compacting-context/references/context-management.md
 	@test -L plugins/workspace-setup/scripts/statusline.sh || (echo "ERROR: plugins/workspace-setup/scripts/statusline.sh is not a symlink" && exit 1)
 	@test -L plugins/workspace-sandbox/scripts/statusline.sh || (echo "ERROR: plugins/workspace-sandbox/scripts/statusline.sh is not a symlink" && exit 1)
 	@diff -q .claude/scripts/read-once/hook.sh plugins/workspace-setup/scripts/read-once/hook.sh


### PR DESCRIPTION
# Summary

The Makefile's `sync_rules` and `check_sync` targets both reference `plugins/codebase-tools/skills/compacting-context/references/context-management.md` — but that path doesn't exist. The `compacting-context` skill lives in **`cc-meta`**, not `codebase-tools`.

Symptoms:
- Every `make check_sync` run prints a stray `diff: ... No such file or directory` warning.
- The cc-meta copy of `context-management.md` (which does exist) was silently drift-prone — no enforcement.

This PR repoints both targets at the correct cc-meta path. Files happen to be identical today, so content is a no-op; the fix re-establishes drift protection going forward.

Closes N/A

## Type of Change

- [x] `chore` — tooling, config, maintenance

## Self-Review

- [x] Diff reviewed; only Makefile path strings changed.
- [x] Commit message follows `.gitmessage` format.

## Testing

- [x] `make check_sync` now passes cleanly with no warning (verified locally).
- [x] `make validate` passes.
- No plugin file changes → no version bumps needed.

## Documentation

- [ ] `CHANGELOG.md` — skipped: build/tooling fix below the threshold for changelog noise. Happy to add an entry under `Fixed` if maintainers prefer.
- [ ] `LEARNINGS.md` — N/A
- [ ] Plugin README — N/A

🤖 Generated with Claude <noreply@anthropic.com>