### PR TITLE
chore(makefile): drop vestigial cp/diff for read-once scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,8 @@ sync_rules:  ## Sync rules from .claude/rules/ to plugin copies
 	cp .claude/rules/context-management.md plugins/codebase-tools/skills/researching-codebase/references/
 	cp .claude/rules/context-management.md plugins/cc-meta/skills/compacting-context/references/
 
-sync_scripts:  ## Sync scripts from .claude/scripts/ to plugin copies (statusline.sh uses symlinks)
-	cp .claude/scripts/read-once/hook.sh plugins/workspace-setup/scripts/read-once/
-	cp .claude/scripts/read-once/compact.sh plugins/workspace-setup/scripts/read-once/
-	cp .claude/scripts/read-once/hook.sh plugins/workspace-sandbox/scripts/read-once/
-	cp .claude/scripts/read-once/compact.sh plugins/workspace-sandbox/scripts/read-once/
+sync_scripts:  ## Sync scripts from .claude/scripts/ to plugin copies (all script files use symlinks; this is a no-op kept for the `sync` target wiring)
+	@true
 
 sync_refs:  ## Sync shared references within plugins (implementing → reviewing)
 	cp plugins/python-dev/skills/implementing-python/references/python-best-practices.md plugins/python-dev/skills/reviewing-code/references/
@@ -59,10 +56,10 @@ check_sync:  ## Verify all copies are in sync with .claude/ SoT
 	@diff -q .claude/rules/context-management.md plugins/cc-meta/skills/compacting-context/references/context-management.md
 	@test -L plugins/workspace-setup/scripts/statusline.sh || (echo "ERROR: plugins/workspace-setup/scripts/statusline.sh is not a symlink" && exit 1)
 	@test -L plugins/workspace-sandbox/scripts/statusline.sh || (echo "ERROR: plugins/workspace-sandbox/scripts/statusline.sh is not a symlink" && exit 1)
-	@diff -q .claude/scripts/read-once/hook.sh plugins/workspace-setup/scripts/read-once/hook.sh
-	@diff -q .claude/scripts/read-once/compact.sh plugins/workspace-setup/scripts/read-once/compact.sh
-	@diff -q .claude/scripts/read-once/hook.sh plugins/workspace-sandbox/scripts/read-once/hook.sh
-	@diff -q .claude/scripts/read-once/compact.sh plugins/workspace-sandbox/scripts/read-once/compact.sh
+	@test -L plugins/workspace-setup/scripts/read-once/hook.sh || (echo "ERROR: plugins/workspace-setup/scripts/read-once/hook.sh is not a symlink" && exit 1)
+	@test -L plugins/workspace-setup/scripts/read-once/compact.sh || (echo "ERROR: plugins/workspace-setup/scripts/read-once/compact.sh is not a symlink" && exit 1)
+	@test -L plugins/workspace-sandbox/scripts/read-once/hook.sh || (echo "ERROR: plugins/workspace-sandbox/scripts/read-once/hook.sh is not a symlink" && exit 1)
+	@test -L plugins/workspace-sandbox/scripts/read-once/compact.sh || (echo "ERROR: plugins/workspace-sandbox/scripts/read-once/compact.sh is not a symlink" && exit 1)
 	@diff -q plugins/python-dev/skills/implementing-python/references/python-best-practices.md plugins/python-dev/skills/reviewing-code/references/python-best-practices.md
 	@diff -q plugins/rust-dev/skills/implementing-rust/references/rust-best-practices.md plugins/rust-dev/skills/reviewing-rust/references/rust-best-practices.md
 	@diff -q plugins/go-dev/skills/implementing-go/references/go-best-practices.md plugins/go-dev/skills/reviewing-go/references/go-best-practices.md


### PR DESCRIPTION
# Summary

The read-once `hook.sh` and `compact.sh` files in `plugins/workspace-{setup,sandbox}/scripts/read-once/` are already symlinks to `.claude/scripts/read-once/` — same pattern as `statusline.sh`. The Makefile carried stale `cp` lines in `sync_scripts` and stale `diff -q` lines in `check_sync` as if they were copies, which was redundant noise and could mask drift if the symlinks were ever replaced with real files.

This PR:

- Drops the `cp` lines from `sync_scripts` (now a no-op, kept only so the aggregate `sync` target wiring stays intact).
- Replaces the `diff -q` lines in `check_sync` with `test -L` invariant checks — same shape `statusline.sh` already uses.

Closes N/A

## Type of Change

- [x] `chore` — tooling, config, maintenance

## Self-Review

- [x] Diff reviewed; only Makefile changes.
- [x] Commit message follows `.gitmessage` format.

## Testing

- [x] `make sync` passes (no-op for scripts now, but doesn't fail)
- [x] `make check_sync` passes — symlink invariants enforced for all 6 shared scripts (statusline + 4 read-once)
- [x] `make validate` passes
- No plugin file changes → no version bumps needed.

## Documentation

- [ ] `CHANGELOG.md` — skipped: build/tooling cleanup below changelog noise threshold.
- [ ] `LEARNINGS.md` — N/A
- [ ] Plugin README — N/A

## Background

This is the first piece of the SoT redundancy cleanup discussed in this session. Follow-up PR will convert `.claude/rules/*.md` from `cp`-enforced copies to symlinks across the plugin trees that consume them (workspace-setup/rules, workspace-sandbox/rules, codebase-tools/researching-codebase/references, cc-meta/compacting-context/references).

🤖 Generated with Claude <noreply@anthropic.com>