### PR TITLE
refactor(skills): front-load market-research and ralph descriptions with action verbs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
       "name": "ralph",
       "source": "./plugins/ralph",
       "description": "PRD-to-JSON conversion, interactive user story builder, and PRD generation for the Ralph loop",
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     {
       "name": "embedded-dev",
@@ -96,7 +96,7 @@
       "name": "market-research",
       "source": "./plugins/market-research",
       "description": "GTM market research pipeline with teams mode parallel dispatch and configurable 2x2 strategy matrix",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "rust-dev",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`.claude/rules/skill-authoring.md`**: Agents convention section added — documents `plugins/<name>/agents/<agent-name>.md` layout, host-plugin selection, README `## Agents` section requirement, cherry-pick attribution template (#112)
 - **`.claude/rules/core-principles.md`**: Tightened 73 → 55 lines — kept acronym expansions (KISS, DRY, AHA, YAGNI) and added failure-mode glosses where the name alone wasn't self-evident; folded "User-Centric Principles" into the intro; merged "Reuse and Extend" + "Resolve Ambiguity" into "Match existing patterns; ask before diverging"; preserved Consistency-and-Coherence, Rigor-and-Sufficiency, High-Impact-Quick-Wins, Clarity, Actionable-and-Concrete, Root-Cause-and-First-Principles, and Touch-only-task-related-code as named bullets. workspace-setup 1.3.11 → 1.3.12, workspace-sandbox 1.3.10 → 1.3.11.
 - **`.claude/rules/skill-authoring.md`**: Resolved internal contradiction on `references/` requirement — adopted conditional reading (mandatory only when extraction is triggered by the 150-line cap), consistent with the SKILL.md body-size section.
+- **market-research**: Front-loaded all 8 skill descriptions with action verbs (Assess/Map/Integrate/Score/Develop/Detect/Synthesize/Generate) per skill-authoring convention; phase labels moved to suffix so ordering info is preserved. Plugin version 1.0.1 → 1.0.2.
+- **ralph**: Front-loaded `generating-interactive-userstory-md` description (verb-led "Build UserStory.md interactively..."). Plugin version 1.0.2 → 1.0.3.
 
 ### Fixed
 

--- a/plugins/market-research/.claude-plugin/plugin.json
+++ b/plugins/market-research/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "market-research",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "GTM market research pipeline with teams mode parallel dispatch and configurable 2x2 strategy matrix",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["market-research", "gtm", "go-to-market", "strategy", "competitive-intelligence", "product-market-fit"]

--- a/plugins/market-research/skills/analyzing-contradictions/SKILL.md
+++ b/plugins/market-research/skills/analyzing-contradictions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyzing-contradictions
-description: Phase 4 — Gap detection and contradiction analysis across all prior phases. Surfaces cross-phase tensions, unresolved assumptions, and sales/investor objections. Use after developing-gtm-strategy completes.
+description: Detect gaps and contradictions across all prior phases; surface cross-phase tensions, unresolved assumptions, and sales/investor objections. Run after `developing-gtm-strategy` (Phase 4).
 compatibility: Designed for Claude Code
 metadata:
   stability: development

--- a/plugins/market-research/skills/analyzing-source-project/SKILL.md
+++ b/plugins/market-research/skills/analyzing-source-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyzing-source-project
-description: Phase 0 — Technical capability assessment of a source project. Reads config/sources.md and produces a structured capability profile. Use to start the GTM pipeline or when evaluating a project's technical differentiators.
+description: Assess a source project's technical capabilities. Reads `config/sources.md` and produces a structured capability profile. Use to start the GTM pipeline or evaluate technical differentiators (Phase 0).
 compatibility: Designed for Claude Code
 metadata:
   stability: development

--- a/plugins/market-research/skills/developing-gtm-strategy/SKILL.md
+++ b/plugins/market-research/skills/developing-gtm-strategy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developing-gtm-strategy
-description: Phase 3 — Customer segmentation, channel selection, and 90-day launch plan. Depends on Phase 2 PMF assessment. Use after validating-product-market-fit completes.
+description: Develop customer segmentation, channel selection, and a 90-day launch plan from Phase 2 PMF assessment. Run after `validating-product-market-fit` (Phase 3).
 compatibility: Designed for Claude Code
 metadata:
   stability: development

--- a/plugins/market-research/skills/generating-slide-deck/SKILL.md
+++ b/plugins/market-research/skills/generating-slide-deck/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: generating-slide-deck
-description: Phase 6 — Investor or stakeholder presentation generated from Phase 5 synthesis. Produces a structured slide outline with headlines, talking points, and data citations. Use after synthesizing-research completes.
+description: Generate an investor or stakeholder presentation from Phase 5 synthesis; produces a structured slide outline with headlines, talking points, and data citations. Run after `synthesizing-research` (Phase 6).
 compatibility: Designed for Claude Code
 metadata:
   stability: development

--- a/plugins/market-research/skills/researching-industry-landscape/SKILL.md
+++ b/plugins/market-research/skills/researching-industry-landscape/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: researching-industry-landscape
-description: Phase 1A — Competitive intelligence and industry landscape mapping. Runs in parallel with Phase 0. Produces a competitor map and whitespace analysis. Use at the start of the GTM pipeline alongside analyzing-source-project.
+description: Map competitive intelligence and industry landscape; produce a competitor map and whitespace analysis. Run alongside `analyzing-source-project` at the start of the GTM pipeline (Phase 1A).
 compatibility: Designed for Claude Code
 metadata:
   stability: development

--- a/plugins/market-research/skills/researching-market/SKILL.md
+++ b/plugins/market-research/skills/researching-market/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: researching-market
-description: Phase 1B — Strategic market research integrating Phase 0 and Phase 1A outputs. Produces TAM/SAM/SOM sizing, buyer personas, and market entry signals. Use after analyzing-source-project and researching-industry-landscape complete.
+description: Integrate Phase 0 and Phase 1A outputs into TAM/SAM/SOM sizing, buyer personas, and market entry signals. Run after `analyzing-source-project` and `researching-industry-landscape` (Phase 1B).
 compatibility: Designed for Claude Code
 metadata:
   stability: development

--- a/plugins/market-research/skills/synthesizing-research/SKILL.md
+++ b/plugins/market-research/skills/synthesizing-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: synthesizing-research
-description: Phase 5 — Cross-phase integration synthesizing all prior research into a unified GTM narrative. Depends on Phases 0-4. Use after analyzing-contradictions completes to prepare for slide deck generation.
+description: Synthesize all prior research into a unified GTM narrative. Run after `analyzing-contradictions` to prepare for slide deck generation (Phase 5).
 compatibility: Designed for Claude Code
 metadata:
   stability: development

--- a/plugins/market-research/skills/validating-product-market-fit/SKILL.md
+++ b/plugins/market-research/skills/validating-product-market-fit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validating-product-market-fit
-description: Phase 2 — Product-market fit scoring using Phase 1B market analysis. Produces PMF score, evidence matrix, and risk register. Use after researching-market completes.
+description: Score product-market fit from Phase 1B market analysis; produce PMF score, evidence matrix, and risk register. Run after `researching-market` (Phase 2).
 compatibility: Designed for Claude Code
 metadata:
   stability: development

--- a/plugins/ralph/.claude-plugin/plugin.json
+++ b/plugins/ralph/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "PRD-to-JSON conversion and interactive user story builder for the Ralph loop",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["ralph", "prd", "userstory"]

--- a/plugins/ralph/skills/generating-interactive-userstory-md/SKILL.md
+++ b/plugins/ralph/skills/generating-interactive-userstory-md/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: generating-interactive-userstory-md
-description: Interactive Q&A to build UserStory.md from user input. Use when the user wants to create a user story document or start the assisted workflow.
+description: Build UserStory.md interactively via Q&A. Use when the user wants to create a user story document or start the assisted workflow.
 compatibility: Designed for Claude Code
 metadata:
   allowed-tools: AskUserQuestion, Read, Write, WebFetch, WebSearch


### PR DESCRIPTION
# Summary

Second PR in the rules-on-skills audit follow-up (see session `cc-plugins-audit-rules-on-skills`). Front-loads 9 skill descriptions per the `.claude/rules/skill-authoring.md` "Descriptions" rule (start with verb + domain, NOT generic framing).

## What changed

**market-research × 8 skills** — all previously opened with `"Phase N — ..."` (a label, not an action verb). Now lead with concrete action verbs and move the phase label to a suffix:

| Skill | Old opening | New opening |
|---|---|---|
| `analyzing-source-project` | `"Phase 0 — Technical capability assessment..."` | `"Assess a source project's technical capabilities..."` |
| `researching-industry-landscape` | `"Phase 1A — Competitive intelligence..."` | `"Map competitive intelligence and industry landscape..."` |
| `researching-market` | `"Phase 1B — Strategic market research..."` | `"Integrate Phase 0 and Phase 1A outputs into TAM/SAM/SOM sizing..."` |
| `validating-product-market-fit` | `"Phase 2 — Product-market fit scoring..."` | `"Score product-market fit from Phase 1B market analysis..."` |
| `developing-gtm-strategy` | `"Phase 3 — Customer segmentation..."` | `"Develop customer segmentation, channel selection..."` |
| `analyzing-contradictions` | `"Phase 4 — Gap detection..."` | `"Detect gaps and contradictions across all prior phases..."` |
| `synthesizing-research` | `"Phase 5 — Cross-phase integration..."` | `"Synthesize all prior research into a unified GTM narrative..."` |
| `generating-slide-deck` | `"Phase 6 — Investor or stakeholder presentation..."` | `"Generate an investor or stakeholder presentation from Phase 5 synthesis..."` |

**ralph × 1 skill** — previously opened noun-led:

| Skill | Old opening | New opening |
|---|---|---|
| `generating-interactive-userstory-md` | `"Interactive Q&A to build UserStory.md..."` | `"Build UserStory.md interactively via Q&A..."` |

All new descriptions stay under 250 chars (range: 129-205).

## Versions

- `market-research`: 1.0.1 → 1.0.2
- `ralph`: 1.0.2 → 1.0.3
- Matching marketplace.json entries bumped in lockstep.

Closes N/A

## Type of Change

- [x] `refactor` — no functional change (description rewrites)
- [x] `chore` — version bumps
- [x] `docs` — CHANGELOG entry

## Self-Review

- [x] I have reviewed my own diff and removed debug/dead code
- [x] Commit messages follow `.gitmessage` format

## Testing

- [x] `make validate` passes
- [x] `make check_sync` passes
- [x] No skills affected are `stability: stable`, so no content-hash regen needed

## Documentation

- [x] `CHANGELOG.md` updated under `## [Unreleased]` → `### Changed`
- [x] No README updates needed (descriptions live in SKILL.md frontmatter)

## Test plan

- [ ] Spot-check that each new description still names the concrete artifacts (sources.md, TAM/SAM/SOM, PMF score, etc.)
- [ ] Verify phase ordering info is still derivable from the descriptions

🤖 Generated with Claude <noreply@anthropic.com>