### PR TITLE
refactor(readme-generator): extract writing-readme templates to references/

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -165,7 +165,7 @@
       "name": "readme-generator",
       "source": "./plugins/readme-generator",
       "description": "Generate and audit README.md files for repos, GitHub accounts, and organizations",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "planning",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`.claude/rules/skill-authoring.md`**: Resolved internal contradiction on `references/` requirement — adopted conditional reading (mandatory only when extraction is triggered by the 150-line cap), consistent with the SKILL.md body-size section.
 - **market-research**: Front-loaded all 8 skill descriptions with action verbs (Assess/Map/Integrate/Score/Develop/Detect/Synthesize/Generate) per skill-authoring convention; phase labels moved to suffix so ordering info is preserved. Plugin version 1.0.1 → 1.0.2.
 - **ralph**: Front-loaded `generating-interactive-userstory-md` description (verb-led "Build UserStory.md interactively..."). Plugin version 1.0.2 → 1.0.3.
+- **readme-generator**: `writing-readme` SKILL.md 197 → 70 lines (under the 150-line cap); extracted four README template snippets (GitHub Action, Library/Application, Account, Organization) and per-scope conventions to `references/readme-templates.md`. Description tightened from 290 → 225 chars and front-loaded with action verb. Plugin version 1.0.0 → 1.0.1.
 
 ### Fixed
 

--- a/plugins/readme-generator/.claude-plugin/plugin.json
+++ b/plugins/readme-generator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-generator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generate and audit README.md files for repos, GitHub accounts, and organizations",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["readme", "profile", "organization", "github", "documentation", "audit"]

--- a/plugins/readme-generator/skills/writing-readme/SKILL.md
+++ b/plugins/readme-generator/skills/writing-readme/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-readme
-description: Generate or update README.md files for repositories, GitHub user profiles, or GitHub organizations. Use when creating a new README, updating an existing one, or converting a repo README to follow org conventions. Supports repo, account (user profile), and org (organization profile) scopes.
+description: Generate or update README.md files across three scopes — repo (with project-type detection), account (GitHub user profile), and org (organization profile). Use when creating, updating, or aligning a README to org conventions.
 compatibility: Designed for Claude Code
 metadata:
   argument-hint: <scope> [target]
@@ -57,136 +57,9 @@ If no scope is given, default to `repo` for the current working directory.
 
 ## Phase 3: Apply Template
 
-### Repo README — GitHub Action
+See `references/readme-templates.md` for the four template snippets and per-scope conventions (GitHub Action, Library/Application, Account, Organization).
 
-```markdown
-# repo-name
-
-![Version](https://img.shields.io/badge/version-X.Y.Z-8A2BE2)
-![License](https://img.shields.io/badge/license-Apache--2.0-blue)
-![Test Action](https://github.com/owner/repo/actions/workflows/test-action.yaml/badge.svg)
-![CodeFactor](https://www.codefactor.io/repository/github/owner/repo/badge)
-![CodeQL](https://github.com/owner/repo/actions/workflows/codeql.yaml/badge.svg)
-![Dependabot](https://img.shields.io/badge/dependabot-enabled-025e8c)
-<!-- Add ruff/pytest badges for Python actions, BATS badge for shell actions -->
-
-One-line description.
-
-## Inputs
-
-| Name | Required | Default | Description |
-|------|----------|---------|-------------|
-| ... | ... | ... | ... |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| ... | ... |
-
-## Usage
-
-\`\`\`yaml
-name: Example
-on: [push]
-jobs:
-  example:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: owner/repo@vX
-        with:
-          input_name: value
-\`\`\`
-
-## What it does
-
-1. Step one
-2. Step two
-3. Step three
-
-## License
-
-[License-Type](LICENSE)
-```
-
-**Conventions:**
-- Input table columns: Name | Required | Default | Description (this order)
-- Version badge immediately after H1
-- Usage section has a complete, copy-pasteable workflow
-- "What it does" uses numbered steps
-- License links to `LICENSE` file (never `LICENSE.md`)
-
-### Repo README — Library/Application
-
-```markdown
-# repo-name
-
-One-line description.
-
-## Installation
-
-\`\`\`bash
-install command
-\`\`\`
-
-## Quick Start
-
-\`\`\`python
-minimal usage example
-\`\`\`
-
-## License
-
-[License-Type](LICENSE)
-```
-
-### Account Profile README
-
-```markdown
-# Display Name
-
-Tagline or bio — who you are in one sentence.
-
-### Current focus
-
-- What you're working on now (2-3 bullets)
-
-### Projects
-
-- [**project-name**](url) — one-line description
-- [**project-name**](url) — one-line description
-
-### Tools & languages
-
-Python · Rust · TypeScript · ...
-```
-
-### Organization Profile README
-
-```markdown
-# Org Name
-
-Single-sentence mission.
-
-Optional 2-3 sentence elaboration.
-
----
-
-### What we build
-
-**Domain 1** — brief description with inline links to
-[key-repo-1](url) and [key-repo-2](url).
-
-### Get involved
-
-- CTA 1 → [link](url)
-- Open an issue or PR on any repo.
-```
-
-**Conventions:**
-- File MUST be at `.github/profile/README.md`
-- 150-400 words total
-- License always links to `LICENSE` (never `LICENSE.md`)
+Pick the template matching the scope detected in Phase 1 and the project type detected in Phase 2.
 
 ## Phase 4: Generate
 

--- a/plugins/readme-generator/skills/writing-readme/references/readme-templates.md
+++ b/plugins/readme-generator/skills/writing-readme/references/readme-templates.md
@@ -1,0 +1,136 @@
+# README templates
+
+Template snippets for the four scopes handled by `writing-readme`.
+
+## Repo README — GitHub Action
+
+```markdown
+# repo-name
+
+![Version](https://img.shields.io/badge/version-X.Y.Z-8A2BE2)
+![License](https://img.shields.io/badge/license-Apache--2.0-blue)
+![Test Action](https://github.com/owner/repo/actions/workflows/test-action.yaml/badge.svg)
+![CodeFactor](https://www.codefactor.io/repository/github/owner/repo/badge)
+![CodeQL](https://github.com/owner/repo/actions/workflows/codeql.yaml/badge.svg)
+![Dependabot](https://img.shields.io/badge/dependabot-enabled-025e8c)
+<!-- Add ruff/pytest badges for Python actions, BATS badge for shell actions -->
+
+One-line description.
+
+## Inputs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| ... | ... | ... | ... |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ... | ... |
+
+## Usage
+
+\`\`\`yaml
+name: Example
+on: [push]
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: owner/repo@vX
+        with:
+          input_name: value
+\`\`\`
+
+## What it does
+
+1. Step one
+2. Step two
+3. Step three
+
+## License
+
+[License-Type](LICENSE)
+```
+
+**Conventions:**
+
+- Input table columns: Name | Required | Default | Description (this order)
+- Version badge immediately after H1
+- Usage section has a complete, copy-pasteable workflow
+- "What it does" uses numbered steps
+- License links to `LICENSE` file (never `LICENSE.md`)
+
+## Repo README — Library/Application
+
+```markdown
+# repo-name
+
+One-line description.
+
+## Installation
+
+\`\`\`bash
+install command
+\`\`\`
+
+## Quick Start
+
+\`\`\`python
+minimal usage example
+\`\`\`
+
+## License
+
+[License-Type](LICENSE)
+```
+
+## Account Profile README
+
+```markdown
+# Display Name
+
+Tagline or bio — who you are in one sentence.
+
+### Current focus
+
+- What you're working on now (2-3 bullets)
+
+### Projects
+
+- [**project-name**](url) — one-line description
+- [**project-name**](url) — one-line description
+
+### Tools & languages
+
+Python · Rust · TypeScript · ...
+```
+
+## Organization Profile README
+
+```markdown
+# Org Name
+
+Single-sentence mission.
+
+Optional 2-3 sentence elaboration.
+
+---
+
+### What we build
+
+**Domain 1** — brief description with inline links to
+[key-repo-1](url) and [key-repo-2](url).
+
+### Get involved
+
+- CTA 1 → [link](url)
+- Open an issue or PR on any repo.
+```
+
+**Conventions:**
+
+- File MUST be at `.github/profile/README.md`
+- 150-400 words total
+- License always links to `LICENSE` (never `LICENSE.md`)


### PR DESCRIPTION
# Summary

Third PR in the rules-on-skills audit follow-up (see session `cc-plugins-audit-rules-on-skills`). Brings `writing-readme` into compliance with `.claude/rules/skill-authoring.md` body-size and description caps.

## What changed

- **SKILL.md body: 197 → 70 lines** (cap is 150). Extracted four README template snippets and per-scope conventions to a new `references/readme-templates.md` (139 lines). SKILL.md retains: frontmatter, scope detection (Phase 1), context gathering (Phase 2), generation steps (Phase 4), and rules. Templates accessed via the standard `See references/<file>.md for ...` pointer.
- **Description: 290 → 225 chars** (cap is 250). Front-loaded with the verb "Generate" and concretely names the three scopes (repo/account/org) plus the project-type detection callout.
- **Version bump:** `readme-generator` 1.0.0 → 1.0.1, matching marketplace.json entry.

## Versions

- `readme-generator`: 1.0.0 → 1.0.1

Closes N/A

## Type of Change

- [x] `refactor` — no functional change (structural extraction + description rewrite)
- [x] `chore` — version bump
- [x] `docs` — CHANGELOG entry

## Self-Review

- [x] I have reviewed my own diff and removed debug/dead code
- [x] Commit messages follow `.gitmessage` format

## Testing

- [x] `make validate` passes
- [x] `make check_sync` passes
- [x] Skill is not `stability: stable`, so no content-hash regen needed

## Documentation

- [x] `CHANGELOG.md` updated under `## [Unreleased]` → `### Changed`
- [x] No README updates needed (SKILL.md frontmatter only)

## Test plan

- [ ] Verify `references/readme-templates.md` renders correctly (4 template sections + 2 conventions blocks)
- [ ] Spot-check that the SKILL.md "Phase 3" pointer reads naturally and tells the consumer where to look

🤖 Generated with Claude <noreply@anthropic.com>