### PR TITLE
fix(learnings): clear MD025 and MD031 lint failures on main

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -5,8 +5,6 @@ scope: qte77/claude-code-plugins
 updated: 2026-04-11
 ---
 
-# Plugin Development Learnings
-
 Non-obvious knowledge captured over multiple sessions. Newer sections appended; older sections preserved verbatim.
 
 ## Plugin manifest schemas
@@ -116,6 +114,7 @@ Non-obvious knowledge captured over multiple sessions. Newer sections appended; 
 1. **Verify license** — `gh repo view <owner/repo> --json licenseInfo`. MIT allows reuse with attribution. GPL/non-MIT licenses require escalation.
 2. **Adapt upstream cross-references** — the upstream file may reference agents/skills (`refactor-cleaner`, `architect`, `tdd-guide`, `security-reviewer`) that don't exist in this repo. Rewrite "When NOT to use" or "Complementary skills" sections to point at THIS repo's real skills.
 3. **Add attribution footer** at the bottom of the agent/skill file:
+
    ```markdown
    ## Attribution
 
@@ -123,6 +122,7 @@ Non-obvious knowledge captured over multiple sessions. Newer sections appended; 
    Original path: `<path>`.
    Adapted: <describe local changes>
    ```
+
 4. **Overlap audit** — before importing, compare the upstream artifact against existing skills in this repo. If it duplicates behavior, don't cherry-pick; close the tracking issue as "covered by existing X".
 5. **Decide host plugin** per the agents convention above.
 6. **Bump host plugin version** (plugin-versioning rule).


### PR DESCRIPTION
# Summary

Fixes pre-existing markdownlint failures in `LEARNINGS.md` that have been failing on `main` since #145 landed centralized markdown linting. Unblocks PRs #144, #146, #147 from inheriting red CI.

- **MD025 (single-title/single-h1)** at line 8: frontmatter already declares `title:`, which renders as the document H1. The explicit `# Plugin Development Learnings` heading was a duplicate. Dropped it.
- **MD031 (blanks-around-fences)** at lines 119/125: fenced code block inside numbered-list item 3 lacked blank lines before and after. Added them, which renders correctly as a code block continuation of the list item.

Closes N/A

## Type of Change

- [x] `fix` — bug fix (lint failures)

## Self-Review

- [x] I have reviewed my own diff and removed debug/dead code
- [x] Commit messages follow `.gitmessage` format

## Testing

- [x] Two precise edits, no other changes
- [ ] CI: `Lint MD and Links` markdown job should pass; the `links` job will still fail on pre-existing broken links across the repo (separate cleanup, tracked elsewhere)

## Documentation

- [ ] CHANGELOG entry — skipping; this is a CI-only fix that doesn't change user-facing behavior

🤖 Generated with Claude <noreply@anthropic.com>