### PR TITLE
chore(lint): bump SHA pin and apply inference fixes

### DIFF
--- a/.claude/rules/core-principles.md
+++ b/.claude/rules/core-principles.md
@@ -50,6 +50,6 @@ suggestions to the user.
 
 ## When in Doubt
 
-**STOP. Ask the user.**
+### STOP. Ask the user.
 
 Don't assume, don't over-engineer, don't add complexity.

--- a/.claude/skills/committing-staged-with-message/SKILL.md
+++ b/.claude/skills/committing-staged-with-message/SKILL.md
@@ -24,7 +24,7 @@ Run these commands using the Bash tool to gather context:
 
 Use the Read tool to check `.gitmessage` for commit message format and syntax.
 
-**The commit message body MUST include (concisely — no padding, no redundancy):**
+### The commit message body MUST include (concisely — no padding, no redundancy):
 
 1. **What changed**: bullet points per file or logical group
 2. **Symbols added/removed** (when applicable): functions, classes, tests
@@ -36,7 +36,7 @@ Keep the message laser-focused. Do not repeat the subject line in the body.
 
 ## Step 3: Pause for Approval
 
-**Please review the commit message.**
+### Please review the commit message.
 
 - **Approve**: "yes", "y", "commit", "go ahead"
 - **Edit**: Provide your preferred message

--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   lint:
-    uses: qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f73ac7241ef37b6103e04d2a8373ff68a4  # 2026-04-27
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@55ea1a9910b7dfe02853437345fd76c009cb858f  # 2026-04-27
 ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ agents.** For technical workflows and coding standards, see
 [CONTRIBUTING.md](CONTRIBUTING.md). For project overview, see
 [README.md](README.md).
 
-**External References:**
+### External References:
 
 - @CONTRIBUTING.md - Command reference, testing guidelines, code style patterns
 - @AGENT_REQUESTS.md - Escalation and human collaboration
@@ -31,17 +31,17 @@ agents.** For technical workflows and coding standards, see
 **Priority Order:** User instructions > AGENTS.md compliance > Documentation
 hierarchy > Project patterns > General best practices
 
-**Anti-Scope-Creep Rules:**
+### Anti-Scope-Creep Rules:
 
 - **NEVER implement features without requirement validation**
 - **Always validate implementation decisions against project scope boundaries**
 
-**Anti-Redundancy Rules:**
+### Anti-Redundancy Rules:
 
 - **NEVER duplicate information across documents** - reference authoritative sources
 - **Update authoritative document, then remove duplicates elsewhere**
 
-**When to Escalate to AGENT_REQUESTS.md:**
+### When to Escalate to AGENT_REQUESTS.md:
 
 - User instructions conflict with safety/security practices
 - AGENTS.md rules contradict each other
@@ -50,7 +50,7 @@ hierarchy > Project patterns > General best practices
 
 ## Agent Neutrality Requirements
 
-**ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:**
+### ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:
 
 1. **Extract requirements from specified documents ONLY**
    - Read provided task descriptions or reference materials
@@ -78,7 +78,7 @@ hierarchy > Project patterns > General best practices
 
 ## Quality Thresholds
 
-**Before starting any task, ensure:**
+### Before starting any task, ensure:
 
 - **Context**: 8/10 - Understand requirements, codebase patterns, dependencies
 - **Clarity**: 7/10 - Clear implementation path and expected outcomes
@@ -91,18 +91,18 @@ Gather more context or escalate to AGENT_REQUESTS.md
 
 ## Agent Quick Reference
 
-**Pre-Task:**
+### Pre-Task:
 
 - Read AGENTS.md > CONTRIBUTING.md for technical details
 - Verify quality thresholds met
 
-**During Task:**
+### During Task:
 
 - Use project commands (document deviations)
 - Follow existing patterns and conventions
 - Update documentation when learning patterns
 
-**Post-Task:**
+### Post-Task:
 
 - Run validation - must pass all checks (code tasks only)
 - Update CHANGELOG.md for non-trivial changes

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -3,6 +3,8 @@ title: Agent Learning Documentation
 description: Non-obvious patterns that prevent repeated mistakes across sprints
 ---
 
+# Agent Learnings
+
 ## Template
 
 - **Context**: When/where this applies
@@ -24,6 +26,6 @@ description: Non-obvious patterns that prevent repeated mistakes across sprints
   concurrency:
     group: gh-pages-paint
     cancel-in-progress: false
-  ```
+  ```text
 
 - **References**: qte77/gha-contribution-ascii PR #77; failed run 23672476504.

--- a/AGENT_REQUESTS.md
+++ b/AGENT_REQUESTS.md
@@ -3,7 +3,9 @@ title: Agent Requests to Humans
 description: Escalation protocol and active requests requiring human decision
 ---
 
-**Always escalate when:**
+# Agent Requests
+
+### Always escalate when:
 
 - User instructions conflict with safety/security practices
 - Rules contradict each other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+# Changelog
+
 <!-- markdownlint-disable MD024 no-duplicate-heading -->
 
-# Changelog
+## Changelog
 
 All notable changes to this project will be documented in this file.
 

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -5,6 +5,8 @@ scope: qte77/claude-code-plugins
 updated: 2026-04-11
 ---
 
+# Learnings
+
 Non-obvious knowledge captured over multiple sessions. Newer sections appended; older sections preserved verbatim.
 
 ## Plugin manifest schemas
@@ -121,7 +123,7 @@ Non-obvious knowledge captured over multiple sessions. Newer sections appended; 
    Cherry-picked from [upstream-repo](https://github.com/...) (MIT License, Nk stars) via issue #<N>.
    Original path: `<path>`.
    Adapted: <describe local changes>
-   ```
+   ```bash
 
 4. **Overlap audit** — before importing, compare the upstream artifact against existing skills in this repo. If it duplicates behavior, don't cherry-pick; close the tracking issue as "covered by existing X".
 5. **Decide host plugin** per the agents convention above.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+# README
+
 <!-- markdownlint-disable MD033 -->
 
-# qte77-claude-code-plugins
+## qte77-claude-code-plugins
 
 Claude Code plugin marketplace — 25 plugins, 60 skills, 2 agents from production workflows.
 
@@ -15,7 +17,7 @@ Claude Code plugin marketplace — 25 plugins, 60 skills, 2 agents from producti
 claude plugin marketplace add qte77/claude-code-plugins
 claude plugin install workspace-setup@qte77-claude-code-plugins
 claude plugin install python-dev@qte77-claude-code-plugins
-```
+```bash
 
 <details>
 
@@ -102,7 +104,7 @@ Add to `.claude/settings.json` so teammates get marketplace access:
     }
   }
 }
-```
+```bash
 
 Each member installs plugins individually with `claude plugin install`.
 
@@ -123,7 +125,7 @@ make validate   # Validate plugin structure + JSON syntax
 make sync       # Sync .claude/ SoT into plugin dirs
 make check_sync # Verify all copies match SoT
 make lint_md    # Lint markdown files
-```
+```bash
 
 ### Standalone install and DRY
 

--- a/docs/analysis/CC-plugin-enhancement-analysis.md
+++ b/docs/analysis/CC-plugin-enhancement-analysis.md
@@ -5,6 +5,8 @@ created: 2026-03-01
 updated: 2026-04-04
 ---
 
+# CC Plugin Enhancement Analysis
+
 ## Plugin Structure
 
 ```text
@@ -17,7 +19,7 @@ plugin-name/
 ├── scripts/                     # Helper scripts
 ├── .mcp.json                    # MCP server definitions
 └── README.md
-```
+```text
 
 All component directories at plugin root — not inside `.claude-plugin/`.
 

--- a/plugins/backend-design/README.md
+++ b/plugins/backend-design/README.md
@@ -10,4 +10,4 @@ Backend system architecture and API design skills.
 
 ```bash
 claude plugin install backend-design@qte77-claude-code-plugins
-```
+```text

--- a/plugins/backend-design/skills/designing-backend/SKILL.md
+++ b/plugins/backend-design/skills/designing-backend/SKILL.md
@@ -12,12 +12,14 @@ metadata:
   last-verified-cc-version: 1.0.34
 ---
 
+# Skill
+
 ## Git Context
 
 - Recent changes: !`git log --oneline -3`
 - Current branch: !`git branch --show-current`
 
-# Backend Architecture
+## Backend Architecture
 
 **Target**: $ARGUMENTS
 

--- a/plugins/cc-meta/README.md
+++ b/plugins/cc-meta/README.md
@@ -17,7 +17,7 @@ Claude Code meta-skills for cross-project synthesis and session intelligence.
 
 ```bash
 /summarizing-session-end  # Triggered automatically by SessionEnd hook
-```
+```text
 
 ## SessionEnd Hook Configuration
 
@@ -43,7 +43,7 @@ Add to your `.claude/settings.json` to auto-trigger session summaries:
 /synthesizing-cc-bigpicture Agents-eval              # Single project
 /synthesizing-cc-bigpicture Agents-eval 7d           # Single project, last 7 days
 /synthesizing-cc-bigpicture all 30d ./bigpicture.md  # All projects, 30 days, custom output
-```
+```bash
 
 ## Install
 

--- a/plugins/cc-meta/skills/distilling-plan-learnings/SKILL.md
+++ b/plugins/cc-meta/skills/distilling-plan-learnings/SKILL.md
@@ -24,9 +24,9 @@ that compounds project knowledge over time.
 | 1 | `time-range` | no | `7d` | E.g. `7d`, `30d`, `this-week`. Filter plans by modification time. |
 | 2 | `output-path` | no | `docs/learnings/from-plans.md` | Where to write/append output. |
 
-**Examples:**
+### Examples:
 
-```
+```text
 /distilling-plan-learnings                          # Last 7 days → docs/learnings/from-plans.md
 /distilling-plan-learnings 30d                      # Last 30 days
 /distilling-plan-learnings 7d ./my-learnings.md     # Custom output path
@@ -34,7 +34,7 @@ that compounds project knowledge over time.
 
 ## Data Source
 
-```
+```text
 ~/.claude/
 ├── plans/*.md                       # Plan mode files (filtered by mtime)
 ```
@@ -96,7 +96,7 @@ that compounds project knowledge over time.
 - <pattern>: <context and implication>
 
 ---
-```
+```text
 
 ## Common Pitfalls
 

--- a/plugins/cc-meta/skills/handing-off-session/SKILL.md
+++ b/plugins/cc-meta/skills/handing-off-session/SKILL.md
@@ -69,7 +69,7 @@ focus (e.g. `2026-04-06-session-handoff-skill.md`).
 
 ## Blockers
 [External dependencies, open questions, things that need user input]
-```
+```bash
 
 ## Picking Up a Handoff
 

--- a/plugins/cc-meta/skills/mining-session-patterns/SKILL.md
+++ b/plugins/cc-meta/skills/mining-session-patterns/SKILL.md
@@ -23,9 +23,9 @@ compound learning. Converts raw session data into actionable improvements.
 | 1 | `time-range` | no | `7d` | Period to scan. E.g. `7d`, `30d`, `this-week`. |
 | 2 | `output-path` | no | `docs/patterns/session-patterns.md` | Where to write findings. |
 
-**Examples:**
+### Examples:
 
-```
+```text
 /mining-session-patterns                    # Last 7 days, default output
 /mining-session-patterns 30d                # Last 30 days
 /mining-session-patterns 7d ./patterns.md   # Custom output path
@@ -33,7 +33,7 @@ compound learning. Converts raw session data into actionable improvements.
 
 ## Data Source
 
-```
+```text
 ~/.claude/projects/*/*.jsonl    # Session transcripts
 ```
 
@@ -89,7 +89,7 @@ to respect context budget.
 
 ## Recommended Actions
 - <Concrete improvement derived from patterns above>
-```
+```text
 
 ## Quality Check
 

--- a/plugins/cc-meta/skills/orchestrating-parallel-workers/SKILL.md
+++ b/plugins/cc-meta/skills/orchestrating-parallel-workers/SKILL.md
@@ -62,7 +62,7 @@ This ensures true parallel execution. Each agent prompt must include:
 
 Use TaskCreate for each dispatched unit to give the user visibility:
 
-```
+```yaml
 TaskCreate: "worker-auth: implement OAuth module" — status: in_progress
 TaskCreate: "worker-docs: write API reference" — status: in_progress
 ```

--- a/plugins/cc-meta/skills/persisting-bigpicture-learnings/SKILL.md
+++ b/plugins/cc-meta/skills/persisting-bigpicture-learnings/SKILL.md
@@ -24,9 +24,9 @@ append-only archive for compound cross-session learning.
 | 1 | `input-path` | no | `bigpicture.md` | Path to bigpicture synthesis output |
 | 2 | `hub-path` | no | `docs/learnings/cc-bigpicture/` | Directory for learnings hub |
 
-**Examples:**
+### Examples:
 
-```
+```text
 /persisting-bigpicture-learnings
 /persisting-bigpicture-learnings ~/.claude/bigpicture.md
 /persisting-bigpicture-learnings bigpicture.md docs/learnings/cc-bigpicture/
@@ -34,7 +34,7 @@ append-only archive for compound cross-session learning.
 
 ## Output Structure
 
-```
+```text
 docs/learnings/cc-bigpicture/
 ├── latest.md          # Always the most recent synthesis
 └── archive/
@@ -68,7 +68,7 @@ docs/learnings/cc-bigpicture/
 
 Runs after `/synthesizing-cc-bigpicture`. Chain the two skills:
 
-```
+```text
 /synthesizing-cc-bigpicture all 7d bigpicture.md
 /persisting-bigpicture-learnings bigpicture.md docs/learnings/cc-bigpicture/
 ```

--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/SKILL.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/SKILL.md
@@ -24,7 +24,7 @@ into a coherent narrative of what you're working on, why, and where you're heade
 | 2 | `time-range` | no | all time | E.g. `7d`, `30d`, `this-week`. |
 | 3 | `output-path` | no | auto | Where to write output. |
 
-**Default output path:**
+### Default output path:
 - `project-name` set: `<decoded-project-path>/docs/bigpicture.md`
 - `all` or omitted: `~/.claude/bigpicture.md`
 - Explicit `output-path`: overrides both.
@@ -32,9 +32,9 @@ into a coherent narrative of what you're working on, why, and where you're heade
 **Project matching**: Matched against decoded `~/.claude/projects/<encoded-path>/`
 directories (`-` → `/` in encoding). Substring match on any path segment.
 
-**Examples:**
+### Examples:
 
-```
+```text
 /synthesizing-cc-bigpicture                          # All → ~/.claude/bigpicture.md
 /synthesizing-cc-bigpicture Agents-eval              # Single → project docs/
 /synthesizing-cc-bigpicture Agents-eval 7d           # Single, last 7 days

--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/cc-data-sources.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/cc-data-sources.md
@@ -15,6 +15,6 @@ Full layout of the `~/.claude/` directory as consumed by `synthesizing-cc-bigpic
 ├── plans/*.md                       # Plan mode files
 ├── tasks/<session-or-team-name>/    # Tasks (*.json, skip .lock/.highwatermark)
 └── teams/<team-name>/               # config.json + inboxes/<member>.json
-```
+```text
 
 **Critical:** Never bulk-read full `.jsonl` transcripts. Use `history.jsonl` for discovery and first+last 5 lines of each session transcript for metadata only.

--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/cc-entry-types.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/cc-entry-types.md
@@ -30,7 +30,7 @@ Each line in a session `.jsonl` file is a JSON object with a `type` field:
   "project": "/workspaces/my-project",
   "sessionId": "uuid"
 }
-```
+```text
 
 Use for session discovery (unique `sessionId` values), timeline reconstruction,
 and prompt topic analysis. Preferred over globbing `.jsonl` files when
@@ -72,7 +72,7 @@ Use for trajectory signal (active vs. stale days, trend detection).
   "blocks": ["4", "5"],
   "blockedBy": ["1"]
 }
-```
+```text
 
 The `blocks`/`blockedBy` arrays create a dependency graph within a task list.
 Task directories also contain `.lock` and `.highwatermark` state files (skip these).

--- a/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/output-template.md
+++ b/plugins/cc-meta/skills/synthesizing-cc-bigpicture/references/output-template.md
@@ -24,7 +24,7 @@ The standard markdown template for `bigpicture.md` output. Every synthesis run s
 ## TODOs & DONEs
 ## Blockers & Stale Items
 ## Mode Transitions Needed
-```
+```text
 
 ## Notes
 

--- a/plugins/codebase-tools/README.md
+++ b/plugins/codebase-tools/README.md
@@ -17,4 +17,4 @@ Codebase research, context compaction, and build/quality support with ACE-FCA pr
 
 ```bash
 claude plugin install codebase-tools@qte77-claude-code-plugins
-```
+```text

--- a/plugins/codebase-tools/agents/build-error-resolver.md
+++ b/plugins/codebase-tools/agents/build-error-resolver.md
@@ -25,7 +25,7 @@ npx tsc --noEmit --pretty
 npx tsc --noEmit --pretty --incremental false   # Show all errors
 npm run build
 npx eslint . --ext .ts,.tsx,.js,.jsx
-```
+```bash
 
 ## Workflow
 
@@ -59,7 +59,7 @@ For each error:
 
 ## DO and DON'T
 
-**DO:**
+### DO:
 
 - Add type annotations where missing
 - Add null checks where needed
@@ -68,7 +68,7 @@ For each error:
 - Update type definitions
 - Fix configuration files
 
-**DON'T:**
+### DON'T:
 
 - Refactor unrelated code
 - Change architecture

--- a/plugins/codebase-tools/skills/hardening-codebase/references/lint-tightening-checklist.md
+++ b/plugins/codebase-tools/skills/hardening-codebase/references/lint-tightening-checklist.md
@@ -77,7 +77,7 @@ Tighten one level at a time. Fix violations before tightening further.
 
 Every project needs two recipes:
 
-```
+```text
 autofix    — format + lint --fix (developer convenience)
 lint       — format --check + lint (CI gate, fails on issues)
 complexity — cognitive complexity check (gate, fails above threshold)

--- a/plugins/codebase-tools/skills/hardening-codebase/references/review-agents.md
+++ b/plugins/codebase-tools/skills/hardening-codebase/references/review-agents.md
@@ -5,7 +5,7 @@ list as context to each.
 
 ## Agent 1: Code Reuse
 
-```
+```yaml
 Review changed files for CODE REUSE issues.
 
 For each change:
@@ -21,7 +21,7 @@ Report: file, issue, suggested fix. No false positives.
 
 ## Agent 2: Code Quality
 
-```
+```yaml
 Review changed files for CODE QUALITY and ARCHITECTURE issues.
 
 Look for:
@@ -39,7 +39,7 @@ Report: file, issue, suggested fix. Skip false positives.
 
 ## Agent 3: Efficiency
 
-```
+```yaml
 Review changed files for EFFICIENCY issues.
 
 Look for:
@@ -55,7 +55,7 @@ Report: file, issue, estimated savings. Skip false positives.
 
 ## Agent 4: KISS / DRY / YAGNI
 
-```
+```yaml
 Review changed files for KISS, DRY, and YAGNI violations.
 Also flag deletion candidates.
 

--- a/plugins/codebase-tools/skills/researching-codebase/SKILL.md
+++ b/plugins/codebase-tools/skills/researching-codebase/SKILL.md
@@ -65,7 +65,7 @@ files_examined: <count>
 
 - Constraint with evidence (`path:line`)
 
-```
+```text
 
 ## Evidence Requirements
 

--- a/plugins/commit-helper/README.md
+++ b/plugins/commit-helper/README.md
@@ -11,4 +11,4 @@ Generate conventional commit messages and pull requests with approval workflow.
 
 ```bash
 claude plugin install commit-helper@qte77-claude-code-plugins
-```
+```text

--- a/plugins/commit-helper/skills/creating-pr-from-branch/SKILL.md
+++ b/plugins/commit-helper/skills/creating-pr-from-branch/SKILL.md
@@ -42,9 +42,9 @@ its sections. If not, use this minimal format:
 ## Commits
 
 <list commits from git log>
-```
+```bash
 
-**Body guidelines:**
+### Body guidelines:
 - Fill template checkboxes where applicable (check items that are done)
 - Include `Closes #N` if the branch name contains an issue number
 - Keep it concise — the diff speaks for itself

--- a/plugins/cpp-desktop/README.md
+++ b/plugins/cpp-desktop/README.md
@@ -12,4 +12,4 @@ C++ desktop application development with wxWidgets, GTK, and Qt frameworks.
 
 ```bash
 claude plugin install cpp-desktop@qte77-claude-code-plugins
-```
+```text

--- a/plugins/cpp-desktop/skills/analyzing-cpp-codebase/SKILL.md
+++ b/plugins/cpp-desktop/skills/analyzing-cpp-codebase/SKILL.md
@@ -44,7 +44,7 @@ grep -rn "find_package\|pkg_check_modules" CMakeLists.txt */CMakeLists.txt 2>/de
 
 # Include graph (most-included headers)
 grep -rh '#include "' src/ include/ 2>/dev/null | sort | uniq -c | sort -rn | head -20
-```
+```text
 
 ## Architecture Assessment
 

--- a/plugins/cpp-desktop/skills/implementing-cpp/SKILL.md
+++ b/plugins/cpp-desktop/skills/implementing-cpp/SKILL.md
@@ -74,7 +74,7 @@ and CMake best practices. No over-engineering.
   else()
     # Linux/Unix
   endif()
-  ```
+  ```bash
 
 ## Platform Compilation
 

--- a/plugins/docs-generator/README.md
+++ b/plugins/docs-generator/README.md
@@ -14,7 +14,7 @@ Try it out after installing:
 
 ```text
 /generating-writeup quantum computing IEEE
-```
+```bash
 
 This will generate a structured writeup on the given topic with IEEE-style
 citations, BibTeX bibliography, and a pandoc command to produce the final PDF.
@@ -49,4 +49,4 @@ make -f $CLAUDE_PLUGIN_ROOT/Makefile setup_pdf_converter
 
 ```bash
 claude plugin install docs-generator@qte77-claude-code-plugins
-```
+```text

--- a/plugins/docs-generator/skills/generating-report/references/report-structure.md
+++ b/plugins/docs-generator/skills/generating-report/references/report-structure.md
@@ -59,7 +59,7 @@ period: YYYY-MM-DD to YYYY-MM-DD
 | Metric | Previous | Current | Target |
 |--------|----------|---------|--------|
 | <Metric 1> | <Value> | <Value> | <Value> |
-```
+```yaml
 
 ## Assessment Report
 
@@ -185,7 +185,7 @@ severity: SEV-1 | SEV-2 | SEV-3 | SEV-4
 ## Lessons Learned
 
 <Key takeaways for the team and organization.>
-```
+```yaml
 
 ## Executive Summary
 

--- a/plugins/docs-generator/skills/generating-tech-spec/SKILL.md
+++ b/plugins/docs-generator/skills/generating-tech-spec/SKILL.md
@@ -45,7 +45,7 @@ Read these before proceeding:
 
 ## Output Naming
 
-```
+```yaml
 ADR:      docs/adr/NNNN-<slug>.md        (e.g., 0003-use-event-sourcing.md)
 RFC:      docs/rfc/NNNN-<slug>.md        (e.g., 0001-api-versioning.md)
 Design:   docs/specs/<date>-<slug>.md    (e.g., 2026-03-01-auth-redesign.md)

--- a/plugins/docs-generator/skills/generating-tech-spec/references/tech-spec-formats.md
+++ b/plugins/docs-generator/skills/generating-tech-spec/references/tech-spec-formats.md
@@ -65,7 +65,7 @@ Chosen option: "<Option N>", because <justification>.
 ## More Information
 
 <Links to related ADRs, issues, or documents.>
-```
+```yaml
 
 ## RFC — Request for Comments
 
@@ -186,7 +186,7 @@ reviewers: <Comma-separated names>
 ## Open Questions
 
 <Unresolved design decisions.>
-```
+```yaml
 
 ## Proposal
 

--- a/plugins/docs-generator/skills/generating-writeup/SKILL.md
+++ b/plugins/docs-generator/skills/generating-writeup/SKILL.md
@@ -56,7 +56,7 @@ make -f $CLAUDE_PLUGIN_ROOT/Makefile pandoc_run \
   INPUT_FILES="$$(printf '%s\036' $$dir/*.md)" \
   OUTPUT_FILE="$$dir/output.pdf" \
   BIBLIOGRAPHY="$$dir/09a_bibliography.bib"
-```
+```bash
 
 With custom citation style:
 
@@ -74,7 +74,7 @@ Full writeup build (content generation + PDF):
 ```bash
 make -f $CLAUDE_PLUGIN_ROOT/Makefile writeup \
   WRITEUP_DIR=docs/write-up/<topic>
-```
+```bash
 
 ## Section Numbering (MANDATORY)
 

--- a/plugins/docs-governance/README.md
+++ b/plugins/docs-governance/README.md
@@ -24,7 +24,7 @@ forcing uniform content.
 ```bash
 # Copy skeleton into a new project
 cp ~/.claude/plugins/cache/qte77/claude-code-plugins/plugins/docs-governance/templates/*.md ./
-```
+```bash
 
 ## Install
 

--- a/plugins/docs-governance/rules/frontmatter-convention.md
+++ b/plugins/docs-governance/rules/frontmatter-convention.md
@@ -17,7 +17,7 @@ created: YYYY-MM-DD
 updated: YYYY-MM-DD
 validated_links: YYYY-MM-DD
 ---
-```
+```text
 
 - `title` — descriptive, matches the `# H1` heading
 - `purpose` — one line, used for relevance matching and context decisions

--- a/plugins/docs-governance/skills/enforcing-doc-hierarchy/SKILL.md
+++ b/plugins/docs-governance/skills/enforcing-doc-hierarchy/SKILL.md
@@ -70,7 +70,7 @@ Detect violations across the scope. For each finding, record:
 
    **a) If `markdownlint-cli` is available** (`npx markdownlint-cli --version`
    succeeds): run it with the project config and parse output:
-   ```
+   ```text
    npx markdownlint-cli -c .markdownlint.json <scope> 2>&1
    ```
    Map results to violation types: MD012 → double blanks (fix during align),

--- a/plugins/docs-governance/skills/maintaining-agents-md/SKILL.md
+++ b/plugins/docs-governance/skills/maintaining-agents-md/SKILL.md
@@ -37,7 +37,7 @@ references, missing updates, and promotion candidates.
 
 Scan governance files for staleness and inconsistencies.
 
-**Checks:**
+### Checks:
 
 1. **Stale paths**: Grep governance files for `src/`, `docs/`, `tests/` paths.
    Verify each path still exists.
@@ -65,7 +65,7 @@ Fix staleness found by audit. For each finding:
 Evaluate `AGENT_LEARNINGS.md` entries for promotion per the criteria in
 `.claude/rules/compound-learning.md` (3rd occurrence → rule, recurring → skill).
 
-**Procedure:**
+### Procedure:
 
 1. Read `AGENT_LEARNINGS.md` entries
 2. Grep codebase for each pattern's problem statement

--- a/plugins/embedded-dev/README.md
+++ b/plugins/embedded-dev/README.md
@@ -15,7 +15,7 @@ Embedded firmware development plugin covering the full compliance-to-traceabilit
 
 The skills form a lifecycle pipeline. Each skill's output feeds the next:
 
-```
+```text
 checking-compliance → implementing-firmware → tracing-requirements
                       auditing-pcb-design (standalone)
 ```
@@ -30,4 +30,4 @@ clang-tidy, clang-format, sqlite3, doxygen) via copy-if-not-exists.
 
 ```bash
 claude plugin install embedded-dev@qte77-claude-code-plugins
-```
+```text

--- a/plugins/embedded-dev/skills/auditing-pcb-design/SKILL.md
+++ b/plugins/embedded-dev/skills/auditing-pcb-design/SKILL.md
@@ -30,7 +30,7 @@ Read these before proceeding:
 
    ```bash
    kicad-cli sch erc --output erc-report.json --format json <schematic.kicad_sch>
-   ```
+   ```bash
 
 4. **Run DRC** on PCB:
 
@@ -70,7 +70,7 @@ kicad-cli <version>
 
 ## Recommendations
 ...
-```
+```text
 
 ## Rules
 

--- a/plugins/embedded-dev/skills/auditing-pcb-design/references/kicad-cli-reference.md
+++ b/plugins/embedded-dev/skills/auditing-pcb-design/references/kicad-cli-reference.md
@@ -15,7 +15,7 @@ version: 1.0.0
 ```bash
 kicad-cli version
 # Expected: 8.x or later (CLI introduced in KiCad 8)
-```
+```bash
 
 ## Electrical Rules Check (ERC)
 
@@ -52,7 +52,7 @@ kicad-cli sch erc \
   ],
   "violation_count": 1
 }
-```
+```bash
 
 ### Common ERC Violations
 
@@ -103,7 +103,7 @@ kicad-cli pcb drc \
   "unconnected_count": 0,
   "violation_count": 1
 }
-```
+```bash
 
 ### Common DRC Violations
 
@@ -137,7 +137,7 @@ kicad-cli pcb export drill \
 
 ### Expected Output Files
 
-```
+```text
 gerbers/
   project-F_Cu.gbr          # Front copper
   project-B_Cu.gbr          # Back copper
@@ -159,7 +159,7 @@ kicad-cli sch export bom \
     --output bom.csv \
     --fields "Reference,Value,Footprint,MPN,Manufacturer" \
     project.kicad_sch
-```
+```text
 
 ## References
 

--- a/plugins/embedded-dev/skills/checking-compliance/SKILL.md
+++ b/plugins/embedded-dev/skills/checking-compliance/SKILL.md
@@ -54,7 +54,7 @@ Read these before proceeding:
   - Clause 6.3: Electric shock
 - [ ] EMC 2014/30/EU — EN 55032:2015+A1:2020
   ...
-```
+```text
 
 ### Requirements File
 

--- a/plugins/embedded-dev/skills/checking-compliance/references/compliance-standards.md
+++ b/plugins/embedded-dev/skills/checking-compliance/references/compliance-standards.md
@@ -32,7 +32,7 @@ Key clauses:
 
 Applies to all electrical/electronic equipment that may generate or be affected by electromagnetic disturbance.
 
-**Harmonized standards:**
+### Harmonized standards:
 
 - **EN 55032:2015+A1:2020** — Electromagnetic compatibility of multimedia equipment — Emission requirements
   - Class A: Commercial/industrial environment
@@ -48,7 +48,7 @@ Applies to all electrical/electronic equipment that may generate or be affected 
 
 Applies to equipment that intentionally transmits/receives radio waves (Wi-Fi, Bluetooth, Zigbee, LoRa, cellular).
 
-**Harmonized standards:**
+### Harmonized standards:
 
 - ETSI EN 300 328 (2.4 GHz wideband)
 - ETSI EN 301 893 (5 GHz RLAN)
@@ -95,7 +95,7 @@ Intentional radiators (devices with radio transmitters):
 
 ## Decision Matrix
 
-```
+```text
 Device has radio? ──► YES ──► RED (EU) + FCC Part 15.247+ (US)
        │
        NO

--- a/plugins/embedded-dev/skills/checking-compliance/references/requirement-hierarchy.md
+++ b/plugins/embedded-dev/skills/checking-compliance/references/requirement-hierarchy.md
@@ -13,7 +13,7 @@ see-also: compliance-standards.md
 
 ## Three-Level Structure
 
-```
+```text
 SYS-REQ (System Requirements)
   └── PRD-REQ (Product Requirements)
         └── SW-REQ (Software Requirements)
@@ -29,9 +29,9 @@ Top-level requirements derived from:
 
 **ID format:** `SYS-REQ-NNN` (three-digit, sequential)
 
-**Example:**
+### Example:
 
-```
+```yaml
 SYS-REQ-001: Device shall meet EN 55032 Class B conducted emission limits
 SYS-REQ-002: Device shall comply with IEC 62368-1 clause 5.4 fire safety
 SYS-REQ-003: Device shall support Wi-Fi 802.11b/g/n (2.4 GHz)
@@ -43,9 +43,9 @@ Refinement of SYS-REQ into implementation domains (HW/SW/communication).
 
 **ID format:** `PRD-REQ-NNN` with mandatory `parent: SYS-REQ-NNN`
 
-**Example:**
+### Example:
 
-```
+```yaml
 PRD-REQ-001: EMI filter on power input shall attenuate >60dB at 150kHz
   parent: SYS-REQ-001
 PRD-REQ-004: Software EMV filter shall limit PWM switching noise
@@ -58,9 +58,9 @@ Module-level requirements assigned to specific software components.
 
 **ID format:** `SW-REQ-NNN` with mandatory `parent: PRD-REQ-NNN`
 
-**Example:**
+### Example:
 
-```
+```yaml
 SW-REQ-015: EMV filter module shall implement configurable low-pass filter
   parent: PRD-REQ-004
   module: components/emv_filter
@@ -90,7 +90,7 @@ The standard format for `docs/requirements.md`:
 | ID | Description | Parent | Module | Status |
 |----|-------------|--------|--------|--------|
 | SW-REQ-015 | ... | PRD-REQ-004 | emv_filter | open |
-```
+```text
 
 ## Status Values
 

--- a/plugins/embedded-dev/skills/implementing-firmware/SKILL.md
+++ b/plugins/embedded-dev/skills/implementing-firmware/SKILL.md
@@ -44,7 +44,7 @@ Read these before proceeding:
     * @param ...
     * @return ...
     */
-   ```
+   ```bash
 
 4. **Create test stubs** in `test/` with matching `@test TEST-NNN` references
 5. **Lint with cppcheck:**

--- a/plugins/embedded-dev/skills/implementing-firmware/references/c-safety-rules.md
+++ b/plugins/embedded-dev/skills/implementing-firmware/references/c-safety-rules.md
@@ -34,7 +34,7 @@ cppcheck \
     --xml \
     --output-file=reports/misra-report.xml \
     src/
-```
+```bash
 
 ### ESP-IDF Specific Flags
 
@@ -63,7 +63,7 @@ check_tool = cppcheck
 check_flags =
     cppcheck: --addon=misra.py --std=c11 --enable=all
 check_severity = high, medium
-```
+```yaml
 
 ## clang-tidy Configuration
 
@@ -87,7 +87,7 @@ clang-tidy \
     -checks='clang-analyzer-*,bugprone-*,cert-*,misc-*' \
     -p build/ \
     src/**/*.c
-```
+```text
 
 ## Deviation Documentation
 
@@ -102,7 +102,7 @@ Rationale:      Technical justification for why the rule
 Risk:           Low / Medium / High
 Approved by:    Name, Role
 Date:           YYYY-MM-DD
-```
+```text
 
 In code, mark with inline comment:
 
@@ -128,9 +128,9 @@ Every function implementing a requirement must include:
  * @param name  Parameter description
  * @return      Return value description
  */
-```
+```javascript
 
-**Rules:**
+### Rules:
 
 - `@requirement`, `@parent`, `@test` are mandatory for every tagged function
 - `@status` and `@version` are optional but recommended

--- a/plugins/embedded-dev/skills/implementing-firmware/references/esp-idf-patterns.md
+++ b/plugins/embedded-dev/skills/implementing-firmware/references/esp-idf-patterns.md
@@ -13,7 +13,7 @@ see-also: platformio-patterns.md
 
 ## Project Structure
 
-```
+```text
 project/
   CMakeLists.txt              # Top-level: cmake_minimum_required + project()
   sdkconfig                   # Generated menuconfig output
@@ -43,7 +43,7 @@ idf_component_register(
     REQUIRES driver esp_timer
     PRIV_REQUIRES unity
 )
-```
+```text
 
 ## FreeRTOS Patterns
 
@@ -73,7 +73,7 @@ sensor_data_t received;
 if (xQueueReceive(data_queue, &received, portMAX_DELAY) == pdTRUE) {
     process(received);
 }
-```
+```text
 
 ### Event Groups
 
@@ -101,7 +101,7 @@ if (result != ESP_OK) {
 
 // Or for fatal errors:
 ESP_ERROR_CHECK(some_critical_function());
-```
+```bash
 
 ## Build Commands
 
@@ -123,7 +123,7 @@ CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
 CONFIG_LOG_DEFAULT_LEVEL_INFO=y
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
-```
+```text
 
 ## References
 

--- a/plugins/embedded-dev/skills/implementing-firmware/references/platformio-patterns.md
+++ b/plugins/embedded-dev/skills/implementing-firmware/references/platformio-patterns.md
@@ -13,7 +13,7 @@ see-also: esp-idf-patterns.md
 
 ## Project Structure
 
-```
+```text
 project/
   platformio.ini              # Project configuration
   src/
@@ -49,7 +49,7 @@ check_flags =
 platform = native
 build_flags = -std=c11
 test_framework = unity
-```
+```bash
 
 ## CLI Commands
 
@@ -92,7 +92,7 @@ Place custom libraries in `lib/` with a `library.json`:
   "frameworks": ["espidf"],
   "platforms": ["espressif32"]
 }
-```
+```text
 
 ### External Dependencies
 
@@ -125,7 +125,7 @@ extends = common
 platform = espressif32
 board = esp32-s3-devkitc-1
 framework = espidf
-```
+```text
 
 ## References
 

--- a/plugins/embedded-dev/skills/tracing-requirements/SKILL.md
+++ b/plugins/embedded-dev/skills/tracing-requirements/SKILL.md
@@ -38,7 +38,7 @@ Read these before proceeding:
    - **Dead code candidates:** Functions without any requirement tag
 5. **Output coverage matrix:**
 
-   ```
+   ```text
    | Requirement | Code File:Line | Test ID | Status |
    |-------------|---------------|---------|--------|
    | SW-REQ-001  | src/emv.c:42  | TEST-001| OK     |
@@ -65,7 +65,7 @@ Read these before proceeding:
 
 ## Coverage Matrix
 ...
-```
+```text
 
 ## Rules
 

--- a/plugins/embedded-dev/skills/tracing-requirements/references/requirement-tagging.md
+++ b/plugins/embedded-dev/skills/tracing-requirements/references/requirement-tagging.md
@@ -35,7 +35,7 @@ grep -rn '@test\s\+TEST-[0-9]\{3\}' --include='*.c' test/
 # Extract functions without any requirement tag (dead code candidates)
 # Two-pass: find function definitions, then exclude those with @requirement
 grep -rn '^\w.*\s\+\w\+(.*)\s*{' --include='*.c' src/ | grep -v 'static\s\+inline'
-```
+```text
 
 ## Reconciliation Algorithm
 
@@ -95,7 +95,7 @@ FUNCTION reconcile(requirements_file, source_dirs, test_dirs):
 
     # Step 8: Generate coverage matrix
     RETURN build_matrix(sw_reqs, code_req_tags, test_tags)
-```
+```text
 
 ### Output Categories
 
@@ -115,7 +115,7 @@ FUNCTION reconcile(requirements_file, source_dirs, test_dirs):
 | SW-REQ-001  | EMV filter init...     | src/emv.c:42  | TEST-001| ✓ OK   |
 | SW-REQ-002  | Power monitor...       | —             | —       | ✗ MISS |
 | SW-REQ-003  | WiFi credential...     | src/wifi.c:87 | —       | ~ TEST |
-```
+```yaml
 
 Legend: `✓ OK` = implemented + tested, `✗ MISS` = not implemented, `~ TEST` = implemented but untested
 

--- a/plugins/gha-dev/README.md
+++ b/plugins/gha-dev/README.md
@@ -23,4 +23,4 @@ Grants Bash permissions for: `gh`, `bats`, `shellcheck`, `actionlint`.
 
 ```bash
 claude plugin install gha-dev@qte77-claude-code-plugins
-```
+```text

--- a/plugins/gha-dev/skills/creating-gha/SKILL.md
+++ b/plugins/gha-dev/skills/creating-gha/SKILL.md
@@ -25,7 +25,7 @@ and proper release flow.
 
 See `references/marketplace-checklist.md` for full reference.
 
-**Required `action.yaml` fields:**
+### Required `action.yaml` fields:
 - `name` — unique on Marketplace (check before using)
 - `description` — shown in search results
 - `branding` — `icon` (Feather icon name) + `color` (white/yellow/blue/green/orange/red/purple/gray-dark)
@@ -36,7 +36,7 @@ Pick the layout that matches the action's language:
 
 **Shell-based** (composite with inline `run:` or `scripts/*.sh`):
 
-```
+```text
 action.yaml           # composite action definition + branding
 scripts/              # extracted shell logic (when inline run: grows too large)
 tests/unit/           # BATS test files
@@ -46,7 +46,7 @@ README.md             # usage example with @vN, inputs table, version badge
 
 **Python-based** (composite calling `uv run`):
 
-```
+```bash
 action.yaml           # composite action definition + branding
 src/                  # Python source (app.py entry point)
 tests/                # pytest tests
@@ -60,7 +60,7 @@ See `references/python-gha-patterns.md` for the full Python walkthrough.
 
 ## TDD Workflow
 
-**RED — infra tests first:**
+### RED — infra tests first:
 
 ```bash
 # tests/unit/test_action.bats
@@ -69,15 +69,15 @@ See `references/python-gha-patterns.md` for the full Python walkthrough.
 @test "action.yaml has description field" { grep -q "^description:" action.yaml; }
 @test "action.yaml has branding" { grep -q "^branding:" action.yaml; }
 @test "action.yaml has runs.using composite" { grep -q "using: composite" action.yaml; }
-```
+```bash
 
 Run: `bats tests/unit/` — all must fail first.
 
-**GREEN — implement to pass:**
+### GREEN — implement to pass:
 
 Write `action.yaml` with required fields. Add `scripts/` and steps. Run `bats tests/unit/` — all pass.
 
-**VALIDATE:**
+### VALIDATE:
 
 ```bash
 actionlint
@@ -104,7 +104,7 @@ Never `git push` directly to main.
 actionlint
 shellcheck scripts/*.sh
 bats tests/unit/
-```
+```bash
 
 All must pass before PR creation.
 

--- a/plugins/gha-dev/skills/creating-gha/references/companion-plugins.md
+++ b/plugins/gha-dev/skills/creating-gha/references/companion-plugins.md
@@ -44,7 +44,7 @@ Install with `claude plugin install <name>@qte77-claude-code-utils`.
 claude plugin install tdd-core@qte77-claude-code-utils
 claude plugin install commit-helper@qte77-claude-code-utils
 claude plugin install simplify@qte77-claude-code-utils
-```
+```bash
 
 **Python-based action** (full):
 

--- a/plugins/gha-dev/skills/creating-gha/references/marketplace-checklist.md
+++ b/plugins/gha-dev/skills/creating-gha/references/marketplace-checklist.md
@@ -1,6 +1,6 @@
 # GHA Marketplace Checklist
 
-**First-party references:**
+### First-party references:
 
 - [Creating a composite action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action) — official guide for `runs: using: composite`
 - [Publishing actions to GitHub Marketplace](https://docs.github.com/en/actions/sharing-automations/creating-actions/publishing-actions-in-github-marketplace) — Marketplace listing requirements, branding, and publish flow
@@ -23,7 +23,7 @@ runs:
   steps:
     - shell: bash
       run: echo "hello"
-```
+```python
 
 ## README Requirements
 
@@ -80,7 +80,7 @@ GH_TOKEN="${GH_PAT}" gh pr merge NUM --squash \
   --subject "PR feat: my change (#NUM)" \
   --body "* feat: my change"
 # Note: GITHUB_TOKEN from Codespaces lacks merge permission; use PAT.
-```
+```bash
 
 ## Version Tags
 
@@ -96,7 +96,7 @@ With `bump-my-version` (use `commit=false tag=false` — let the workflow tag):
 [tool.bumpversion]
 commit = false
 tag = false
-```
+```bash
 
 ## Gotchas
 

--- a/plugins/gha-dev/skills/creating-gha/references/python-gha-patterns.md
+++ b/plugins/gha-dev/skills/creating-gha/references/python-gha-patterns.md
@@ -38,7 +38,7 @@ runs:
       run: |
         uv sync --frozen --no-dev --project "${{ github.action_path }}"
         uv run --project "${{ github.action_path }}" python "${{ github.action_path }}/src/app.py"
-```
+```bash
 
 ### Key patterns
 
@@ -93,7 +93,7 @@ Dev tools go in `[dependency-groups]`, not `[project.optional-dependencies]`:
 [dependency-groups]
 dev = ["pytest>=8.0", "ruff>=0.9"]
 lint = ["ruff>=0.9"]
-```
+```bash
 
 - `uv sync --frozen` installs all groups (including dev)
 - `uv sync --frozen --no-dev` installs only `[project] dependencies`
@@ -148,7 +148,7 @@ jobs:
       - run: uv run ruff check .
       - run: uv run ruff format --check .
 ...
-```
+```text
 
 ## File Layout
 
@@ -165,7 +165,7 @@ my-python-action/
     test.yml           # pytest CI
     ruff.yml           # ruff lint + format check
   README.md            # usage with @v1, inputs table, version badge
-```
+```bash
 
 ## Gotchas
 

--- a/plugins/go-dev/README.md
+++ b/plugins/go-dev/README.md
@@ -16,4 +16,4 @@ Go implementation, testing, and code review skills, deploys go tool permissions 
 
 ```bash
 claude plugin install go-dev@qte77-claude-code-plugins
-```
+```text

--- a/plugins/go-dev/skills/implementing-go/SKILL.md
+++ b/plugins/go-dev/skills/implementing-go/SKILL.md
@@ -48,6 +48,6 @@ Before completing any task:
 
 ```bash
 go test ./... && go vet ./... && golangci-lint run
-```
+```text
 
 All tests, vet checks, and linting must pass.

--- a/plugins/go-dev/skills/implementing-go/references/go-best-practices.md
+++ b/plugins/go-dev/skills/implementing-go/references/go-best-practices.md
@@ -6,6 +6,8 @@ purpose: Security-first Go coding standards with concurrency and error handling 
 see-also: testing-strategy.md, tdd-best-practices.md
 ---
 
+# GO Best Practices
+
 ## Security (Non-Negotiable)
 
 ### Input Validation
@@ -27,7 +29,7 @@ func (r *CreateUserRequest) Validate() error {
     }
     return nil
 }
-```
+```text
 
 ### SQL Injection Prevention
 
@@ -50,7 +52,7 @@ var req CreateUserRequest
 if err := dec.Decode(&req); err != nil {
     return fmt.Errorf("invalid request body: %w", err)
 }
-```
+```text
 
 ### Secrets Management
 
@@ -79,7 +81,7 @@ func loadConfig(path string) (*Config, error) {
     }
     return &cfg, nil
 }
-```
+```text
 
 ### Sentinel Errors
 
@@ -110,7 +112,7 @@ var ve *ValidationError
 if errors.As(err, &ve) {
     log.Printf("field %s failed: %s", ve.Field, ve.Message)
 }
-```
+```text
 
 Never ignore errors. When an error truly cannot occur, document why.
 
@@ -134,7 +136,7 @@ Always use two-value form:
 if store, ok := repo.(CacheableStore); ok {
     store.Invalidate(id)
 }
-```
+```text
 
 ### Generics (Go 1.21+)
 
@@ -162,7 +164,7 @@ Pass `context.Context` as the first parameter. Never store in a struct:
 func (s *Service) FetchUser(ctx context.Context, id string) (*User, error) {
     return s.db.QueryRowContext(ctx, "SELECT ...", id)
 }
-```
+```text
 
 Always give goroutines a way to stop:
 
@@ -195,7 +197,7 @@ for _, item := range items {
     }(item)
 }
 wg.Wait()
-```
+```python
 
 Prefer channels for communication; mutexes for state protection.
 
@@ -227,7 +229,7 @@ myapp/
 ├── pkg/                   # Reusable packages (only if truly needed)
 ├── go.mod
 └── go.sum
-```
+```javascript
 
 - `cmd/` — wires dependencies, exits on error
 - `internal/` — default location; cannot be imported externally

--- a/plugins/go-dev/skills/reviewing-go/references/go-best-practices.md
+++ b/plugins/go-dev/skills/reviewing-go/references/go-best-practices.md
@@ -6,6 +6,8 @@ purpose: Security-first Go coding standards with concurrency and error handling 
 see-also: testing-strategy.md, tdd-best-practices.md
 ---
 
+# GO Best Practices
+
 ## Security (Non-Negotiable)
 
 ### Input Validation
@@ -27,7 +29,7 @@ func (r *CreateUserRequest) Validate() error {
     }
     return nil
 }
-```
+```text
 
 ### SQL Injection Prevention
 
@@ -50,7 +52,7 @@ var req CreateUserRequest
 if err := dec.Decode(&req); err != nil {
     return fmt.Errorf("invalid request body: %w", err)
 }
-```
+```text
 
 ### Secrets Management
 
@@ -79,7 +81,7 @@ func loadConfig(path string) (*Config, error) {
     }
     return &cfg, nil
 }
-```
+```text
 
 ### Sentinel Errors
 
@@ -110,7 +112,7 @@ var ve *ValidationError
 if errors.As(err, &ve) {
     log.Printf("field %s failed: %s", ve.Field, ve.Message)
 }
-```
+```text
 
 Never ignore errors. When an error truly cannot occur, document why.
 
@@ -134,7 +136,7 @@ Always use two-value form:
 if store, ok := repo.(CacheableStore); ok {
     store.Invalidate(id)
 }
-```
+```text
 
 ### Generics (Go 1.21+)
 
@@ -162,7 +164,7 @@ Pass `context.Context` as the first parameter. Never store in a struct:
 func (s *Service) FetchUser(ctx context.Context, id string) (*User, error) {
     return s.db.QueryRowContext(ctx, "SELECT ...", id)
 }
-```
+```text
 
 Always give goroutines a way to stop:
 
@@ -195,7 +197,7 @@ for _, item := range items {
     }(item)
 }
 wg.Wait()
-```
+```python
 
 Prefer channels for communication; mutexes for state protection.
 
@@ -227,7 +229,7 @@ myapp/
 ├── pkg/                   # Reusable packages (only if truly needed)
 ├── go.mod
 └── go.sum
-```
+```javascript
 
 - `cmd/` — wires dependencies, exits on error
 - `internal/` — default location; cannot be imported externally

--- a/plugins/go-dev/skills/testing-go/SKILL.md
+++ b/plugins/go-dev/skills/testing-go/SKILL.md
@@ -49,7 +49,7 @@ func TestOrderCalculator_Total_SumsItemPrices(t *testing.T) {
     // ASSERT
     assert.Equal(t, 25.00, total)
 }
-```
+```text
 
 ## Table-Driven Tests (Go Idiom)
 
@@ -93,7 +93,7 @@ See `references/testing-strategy.md` -> "Patterns to Remove" for full list.
 TestUserService_Create_ReturnsIDOnSuccess
 TestValidateEmail_MissingAt
 TestCalculateTotal_EmptyItems
-```
+```bash
 
 ## Execution
 

--- a/plugins/go-dev/skills/testing-go/references/testing-strategy.md
+++ b/plugins/go-dev/skills/testing-go/references/testing-strategy.md
@@ -6,6 +6,8 @@ purpose: Go-specific testing tools and when to use each
 see-also: tdd-best-practices.md
 ---
 
+# Testing Strategy
+
 **Purpose**: Go-specific testing tools and when to use each.
 
 > Language-agnostic testing strategy (what to test, mocking, organization)
@@ -85,7 +87,7 @@ func TestValidateAge(t *testing.T) {
         })
     }
 }
-```
+```text
 
 ## testify: assert vs require
 
@@ -123,7 +125,7 @@ func TestParseRoundTrip(t *testing.T) {
         }
     })
 }
-```
+```text
 
 ## Mocking with Interfaces (No Framework)
 
@@ -155,7 +157,7 @@ mypackage/
 ├── service.go
 ├── service_test.go      # same package or _test suffix
 └── testdata/            # golden files, fixtures
-```
+```text
 
 Use `t.Helper()` in test helpers so failures point to callers.
 

--- a/plugins/makefile-core/README.md
+++ b/plugins/makefile-core/README.md
@@ -22,7 +22,7 @@ Skills and linting for consistent, rigorous Makefiles across projects.
 
 # Standalone lint
 bash plugins/makefile-core/skills/creating-makefile/references/lint-makefile.sh
-```
+```bash
 
 ## Extending
 

--- a/plugins/makefile-core/skills/creating-makefile/SKILL.md
+++ b/plugins/makefile-core/skills/creating-makefile/SKILL.md
@@ -47,7 +47,7 @@ VERBOSE ?= 0
 ifeq ($(VERBOSE),0)
   # quiet flags per tool
 endif
-```
+```bash
 
 ## Conventions
 

--- a/plugins/makefile-core/skills/creating-makefile/references/makefile-conventions.md
+++ b/plugins/makefile-core/skills/creating-makefile/references/makefile-conventions.md
@@ -30,7 +30,7 @@ setup_dev:
 	    curl -sSfL "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" \
 	        | tar -xJ --strip-components=1 -C ~/.local/bin shellcheck-stable/shellcheck
 	fi
-```
+```text
 
 ### Quiet mode
 ```makefile
@@ -46,7 +46,7 @@ endif
 ```makefile
 validate: lint test  ## Full validation (lint + test)
 quick_validate: lint check_types  ## Fast validation (no tests)
-```
+```yaml
 
 ### Conditional dependencies
 ```makefile
@@ -66,7 +66,7 @@ check_docs: ## Lint markdown (user-local node)
         echo "run: make setup_mdlint"
         exit 1
     fi
-```
+```bash
 
 The `export PATH` inside `.ONESHELL` recipes makes npm-installed tools work without the user editing `~/.bashrc`. Required for any recipe invoking `markdownlint-cli2`, `prettier`, or other npm-based tools installed to a user-local Node prefix.
 

--- a/plugins/makefile-core/skills/creating-makefile/references/scaffold-docs.md
+++ b/plugins/makefile-core/skills/creating-makefile/references/scaffold-docs.md
@@ -9,7 +9,7 @@ NODE_VERSION ?= 22.11.0
 NODE_DIR     := $(HOME)/.local/share/node
 NODE_BIN     := $(NODE_DIR)/bin
 LOCAL_BIN    := $(HOME)/.local/bin
-```
+```bash
 
 ## Recipes
 

--- a/plugins/makefile-core/skills/creating-makefile/references/scaffold-python.md
+++ b/plugins/makefile-core/skills/creating-makefile/references/scaffold-python.md
@@ -13,7 +13,7 @@ RUFF_QUIET :=
 PYTEST_QUIET :=
 PYRIGHT_QUIET :=
 endif
-```
+```bash
 
 ## Recipes
 

--- a/plugins/makefile-core/skills/creating-makefile/references/scaffold-shell.md
+++ b/plugins/makefile-core/skills/creating-makefile/references/scaffold-shell.md
@@ -28,7 +28,7 @@ validate: lint test ## Full validation (lint + test)
 
 clean: ## Remove artifacts
     rm -rf tmp/ coverage/
-```
+```bash
 
 ## Notes
 

--- a/plugins/market-research/README.md
+++ b/plugins/market-research/README.md
@@ -19,7 +19,7 @@ Replicates the `qte77/agentic-market-research-to-gtm` workflow as a modern Claud
 
 ## Pipeline
 
-```
+```text
 Phase 0  (analyzing-source-project)      ─┐
 Phase 1A (researching-industry-landscape) ─┤→ Phase 1B → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
 ```
@@ -48,7 +48,7 @@ After installing, configure `config/sources.md` and `config/targets.md`, then ru
 ```text
 /analyzing-source-project https://github.com/owner/repo
 /researching-industry-landscape developer tools
-```
+```bash
 
 Then continue through the pipeline phases sequentially.
 

--- a/plugins/market-research/config-templates/mode.md
+++ b/plugins/market-research/config-templates/mode.md
@@ -6,7 +6,7 @@
 
 Controls output verbosity and depth.
 
-```
+```yaml
 style: concise
 ```
 
@@ -18,7 +18,7 @@ Options:
 
 Controls risk tolerance and ambition of recommendations.
 
-```
+```yaml
 approach: conservative
 ```
 

--- a/plugins/market-research/rules/gtm-pipeline.md
+++ b/plugins/market-research/rules/gtm-pipeline.md
@@ -5,7 +5,7 @@ for the market-research pipeline.
 
 ## Phase Dependency Graph
 
-```
+```text
 Phase 0  (analyzing-source-project)      ─┐
 Phase 1A (researching-industry-landscape) ─┤→ Phase 1B (researching-market)
                                             │      │
@@ -39,7 +39,7 @@ Phase 1A (researching-industry-landscape) ─┤→ Phase 1B (researching-market
 When teams mode is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`), dispatch
 Phase 0 and Phase 1A as parallel subagents:
 
-```
+```text
 Task 1: /analyzing-source-project    → results/phase-0/
 Task 2: /researching-industry-landscape → results/phase-1a/
 Task 3: /researching-market          → blockedBy: [Task 1, Task 2] → results/phase-1b/

--- a/plugins/market-research/rules/validation-loops.md
+++ b/plugins/market-research/rules/validation-loops.md
@@ -5,7 +5,7 @@ quality gates, and escalation rules between phases.
 
 ## Retry Configuration
 
-```
+```yaml
 max_retries: 2
 ```
 
@@ -32,7 +32,7 @@ Escalate to human review when:
 - Phase 5 synthesis confidence rating is Low for more than 50% of major claims.
 
 Escalation output format:
-```
+```yaml
 ESCALATION: [phase-name]
 Failed criteria:
 - [criterion 1]
@@ -52,7 +52,7 @@ summary but may proceed.
 To skip validation for a phase (e.g. for rapid prototyping), add the phase slug
 to a `skip_validation` list in `config/mode.md`:
 
-```
+```yaml
 skip_validation:
   - phase-1a
 ```

--- a/plugins/market-research/skills/analyzing-contradictions/SKILL.md
+++ b/plugins/market-research/skills/analyzing-contradictions/SKILL.md
@@ -56,7 +56,7 @@ Write to `results/phase-4/`:
 
 ### `contradiction-analysis.md`
 
-```
+```text
 # Contradiction Analysis
 
 ## Cross-Phase Contradictions

--- a/plugins/market-research/skills/analyzing-source-project/SKILL.md
+++ b/plugins/market-research/skills/analyzing-source-project/SKILL.md
@@ -46,7 +46,7 @@ Write to `results/phase-0/`:
 
 ### `capability-profile.md`
 
-```
+```text
 # Source Project Capability Profile
 
 ## Project: [name]

--- a/plugins/market-research/skills/developing-gtm-strategy/SKILL.md
+++ b/plugins/market-research/skills/developing-gtm-strategy/SKILL.md
@@ -47,7 +47,7 @@ Write to `results/phase-3/`:
 
 ### `gtm-strategy.md`
 
-```
+```text
 # GTM Strategy
 
 ## Target Segments

--- a/plugins/market-research/skills/generating-slide-deck/SKILL.md
+++ b/plugins/market-research/skills/generating-slide-deck/SKILL.md
@@ -79,7 +79,7 @@ Write to `results/phase-6/`:
 
 ### `slide-deck.md`
 
-```
+```text
 # [Product Name] — [Audience Type] Deck
 
 ---

--- a/plugins/market-research/skills/researching-industry-landscape/SKILL.md
+++ b/plugins/market-research/skills/researching-industry-landscape/SKILL.md
@@ -45,7 +45,7 @@ Write to `results/phase-1a/`:
 
 ### `competitor-map.md`
 
-```
+```text
 # Industry Landscape
 
 ## Competitor Profiles

--- a/plugins/market-research/skills/researching-market/SKILL.md
+++ b/plugins/market-research/skills/researching-market/SKILL.md
@@ -48,7 +48,7 @@ Write to `results/phase-1b/`:
 
 ### `market-analysis.md`
 
-```
+```text
 # Market Analysis
 
 ## Market Sizing

--- a/plugins/market-research/skills/synthesizing-research/SKILL.md
+++ b/plugins/market-research/skills/synthesizing-research/SKILL.md
@@ -51,7 +51,7 @@ Write to `results/phase-5/`:
 
 ### `synthesis.md`
 
-```
+```text
 # GTM Research Synthesis
 
 ## Executive Summary

--- a/plugins/market-research/skills/validating-product-market-fit/SKILL.md
+++ b/plugins/market-research/skills/validating-product-market-fit/SKILL.md
@@ -58,7 +58,7 @@ Write to `results/phase-2/`:
 
 ### `pmf-assessment.md`
 
-```
+```text
 # Product-Market Fit Assessment
 
 ## PMF Score: [X.X] / 10

--- a/plugins/mas-design/README.md
+++ b/plugins/mas-design/README.md
@@ -13,7 +13,7 @@ Try it out after installing:
 
 ```text
 /securing-mas review the current project for MAESTRO, ATLAS, and NIST AI RMF compliance
-```
+```bash
 
 This will audit your multi-agent system design against four complementary
 frameworks — OWASP MAESTRO (7-layer threat model), MITRE ATLAS (adversarial

--- a/plugins/mas-design/skills/designing-mas-plugins/references/core-principles-with-examples.md
+++ b/plugins/mas-design/skills/designing-mas-plugins/references/core-principles-with-examples.md
@@ -7,6 +7,8 @@ version: 1.0.0
 see-also: mas-design-principles.md
 ---
 
+# Core Principles With Examples
+
 Each plugin follows six principles. This file expands each with a worked code example.
 
 ## Stateless Reducer Pattern
@@ -19,7 +21,7 @@ def evaluate(self, context: TierContext) -> TierResult:
     # All inputs from context parameter
     # All outputs in return value
     return TierResult(...)
-```
+```python
 
 ## Own Context Window
 
@@ -45,7 +47,7 @@ class TierResult(BaseModel):
     score: float = Field(ge=0.0, le=1.0)
     reasoning: str
     metrics: dict[str, float]
-```
+```python
 
 ## Own Control Flow
 

--- a/plugins/mas-design/skills/designing-mas-plugins/references/plugin-implementation-template.md
+++ b/plugins/mas-design/skills/designing-mas-plugins/references/plugin-implementation-template.md
@@ -7,6 +7,8 @@ version: 1.0.0
 see-also: core-principles-with-examples.md
 ---
 
+# Plugin Implementation Template
+
 Complete implementation template for a MAS evaluator plugin. Copy and adapt. Follows the six core principles documented in `core-principles-with-examples.md`.
 
 ```python
@@ -79,4 +81,4 @@ class MyPlugin(EvaluatorPlugin):
 
     def _compute(self, context: PluginContext) -> float:
         ...
-```
+```text

--- a/plugins/mas-design/skills/designing-mas-plugins/references/plugin-testing-strategy.md
+++ b/plugins/mas-design/skills/designing-mas-plugins/references/plugin-testing-strategy.md
@@ -7,6 +7,8 @@ version: 1.0.0
 see-also: plugin-implementation-template.md
 ---
 
+# Plugin Testing Strategy
+
 Test plugins in isolation with mocked context. Two minimum test classes: happy path and error handling. Both assert on the structured `PluginResult` — never expect exceptions to propagate.
 
 ```python
@@ -24,4 +26,4 @@ def test_plugin_error_handling():
     result = plugin.evaluate(context)
     # Structured error, not exception
     assert result.error is not None
-```
+```text

--- a/plugins/mas-design/skills/securing-mas/SKILL.md
+++ b/plugins/mas-design/skills/securing-mas/SKILL.md
@@ -36,7 +36,7 @@ NIST AI RMF (risk framework — how to govern/map/measure/manage)
       |  operationalized by
       v
 ISO 42001 + 23894 (certifiable management system + risk methodology)
-```
+```bash
 
 Use all four layers together: ATLAS enumerates attack vectors, MAESTRO maps
 them to MAS-specific controls, NIST AI RMF structures governance, and ISO

--- a/plugins/mas-design/skills/securing-mas/references/common-vulnerabilities.md
+++ b/plugins/mas-design/skills/securing-mas/references/common-vulnerabilities.md
@@ -7,6 +7,8 @@ version: 1.0.0
 see-also: maestro-7-layer-checklist.md
 ---
 
+# Common Vulnerabilities
+
 Vulnerable vs secure code patterns for each MAESTRO layer's highest-impact vulnerability class.
 
 ## Prompt Injection (Layer 1 — Model)
@@ -15,7 +17,7 @@ Vulnerable vs secure code patterns for each MAESTRO layer's highest-impact vulne
 
 ```python
 prompt = f"Evaluate: {user_input}"
-```
+```text
 
 **Secure**:
 
@@ -30,7 +32,7 @@ result = agent.run(EvalContext(text=user_input))
 ```python
 def evaluate(self, context: dict) -> dict:
     return {"score": context["data"]}
-```
+```python
 
 **Secure**:
 
@@ -49,7 +51,7 @@ def evaluate(
 def evaluate(self, context):
     while True:  # Infinite loop
         process(context)
-```
+```python
 
 **Secure**:
 
@@ -65,7 +67,7 @@ def evaluate(self, context):
 
 ```python
 api_key = "sk-1234..."  # Hardcoded
-```
+```text
 
 **Secure**:
 

--- a/plugins/mas-design/skills/securing-mas/references/security-testing-patterns.md
+++ b/plugins/mas-design/skills/securing-mas/references/security-testing-patterns.md
@@ -7,6 +7,8 @@ version: 1.0.0
 see-also: maestro-7-layer-checklist.md
 ---
 
+# Security Testing Patterns
+
 Test security controls explicitly — don't assume they work. Each test names the MAESTRO layer it covers.
 
 ```python
@@ -31,4 +33,4 @@ def test_error_message_safety():
         EvalContext(data="trigger_error")
     )
     assert "secret" not in result.error.lower()
-```
+```text

--- a/plugins/mas-design/skills/securing-mas/references/threat-matrix-template.md
+++ b/plugins/mas-design/skills/securing-mas/references/threat-matrix-template.md
@@ -7,6 +7,8 @@ version: 1.0.0
 see-also: mas-security.md
 ---
 
+# Threat Matrix Template
+
 For each new feature, document threats with cross-framework mapping. Use this matrix as a starting template — add rows for feature-specific concerns.
 
 | Concern | ATLAS Technique | MAESTRO Layer | NIST Function | ISO Control |

--- a/plugins/planning/README.md
+++ b/plugins/planning/README.md
@@ -21,4 +21,4 @@ The `planner` agent is **prospective** (plans a specific thing); the cc-meta ski
 
 ```bash
 claude plugin install planning@qte77-claude-code-plugins
-```
+```text

--- a/plugins/planning/agents/planner.md
+++ b/plugins/planning/agents/planner.md
@@ -5,6 +5,8 @@ tools: ["Read", "Grep", "Glob"]
 model: opus
 ---
 
+# Planner
+
 You are an expert planning specialist focused on creating comprehensive, actionable implementation plans.
 
 ## Your Role
@@ -91,7 +93,7 @@ Create detailed steps with:
 ## Success Criteria
 - [ ] Criterion 1
 - [ ] Criterion 2
-```
+```javascript
 
 ## Best Practices
 

--- a/plugins/python-dev/README.md
+++ b/plugins/python-dev/README.md
@@ -16,4 +16,4 @@ Python implementation, testing, and code review skills, deploys uv permissions v
 
 ```bash
 claude plugin install python-dev@qte77-claude-code-plugins
-```
+```text

--- a/plugins/python-dev/skills/testing-python/SKILL.md
+++ b/plugins/python-dev/skills/testing-python/SKILL.md
@@ -48,7 +48,7 @@ def test_order_processor_calculates_total():
 
     # ASSERT
     assert total == 25.00
-```
+```text
 
 ## Hypothesis Priorities (Edge Cases within TDD)
 
@@ -84,7 +84,7 @@ make test_rerun        # Rerun failed tests (fast iteration)
 make validate          # Full pre-commit validation
 pytest tests/ -v       # Verbose
 pytest -k test_user_   # Filter by name
-```
+```bash
 
 ## Quality Gates
 

--- a/plugins/python-dev/skills/testing-python/references/testing-strategy.md
+++ b/plugins/python-dev/skills/testing-python/references/testing-strategy.md
@@ -6,6 +6,8 @@ purpose: High-level testing strategy aligned with KISS/DRY/YAGNI
 see-also: tdd-best-practices.md
 ---
 
+# Testing Strategy
+
 **Purpose**: Python-specific testing tools and when to use each.
 
 > Language-agnostic testing strategy (what to test, mocking, organization)
@@ -136,7 +138,7 @@ def test_result_with_timestamp():
         "score": 0.85,
         "timestamp": IsDatetime(),  # Not managed by snapshot
     })
-```
+```bash
 
 **Commands**:
 
@@ -227,7 +229,7 @@ def test_order_repository_saves_order(tmp_path):
     repo = OrderRepository(db)
     order = repo.save(Order(total=100))
     assert repo.get(order.id).total == 100
-```
+```text
 
 ### Priority Test Areas
 
@@ -261,7 +263,7 @@ tests/
 │   ├── test_math_props.py
 │   └── test_validation_props.py
 └── conftest.py           # Shared fixtures
-```
+```bash
 
 ## Running Tests
 

--- a/plugins/rag-core/README.md
+++ b/plugins/rag-core/README.md
@@ -15,4 +15,4 @@ Document indexing and hybrid retrieval for RAG pipelines.
 
 ```bash
 claude plugin install rag-core@qte77-claude-code-plugins
-```
+```text

--- a/plugins/rag-core/skills/implementing-document-indexing/SKILL.md
+++ b/plugins/rag-core/skills/implementing-document-indexing/SKILL.md
@@ -19,7 +19,7 @@ sentence-transformers, store in FAISS, and retrieve via hybrid search.
 
 ## Architecture Overview
 
-```
+```text
 Document --> Parser --> Pages --> TreeIndex (PageIndex)
                                      |
                                      v
@@ -86,7 +86,7 @@ class TreeNode:
     children: list[TreeNode]
 
     def filter(self, predicate: Callable) -> TreeNode | None: ...
-```
+```text
 
 ## Dependencies
 
@@ -113,6 +113,6 @@ dependencies = [
 
 ```bash
 make validate
-```
+```text
 
 All type checks, linting, and tests must pass.

--- a/plugins/rag-core/skills/implementing-document-indexing/references/chunking-strategies.md
+++ b/plugins/rag-core/skills/implementing-document-indexing/references/chunking-strategies.md
@@ -17,7 +17,7 @@ Split documents at heading boundaries to preserve semantic coherence.
 
 ```python
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
-```
+```python
 
 For non-Markdown sources, map structural elements to heading levels:
 
@@ -66,7 +66,7 @@ When a single section exceeds the token budget, split further.
 
 ```python
 SENTENCE_END = re.compile(r"(?<=[.!?])\s+(?=[A-Z])")
-```
+```python
 
 Never split:
 

--- a/plugins/rag-core/skills/implementing-document-indexing/references/retrieval-patterns.md
+++ b/plugins/rag-core/skills/implementing-document-indexing/references/retrieval-patterns.md
@@ -30,7 +30,7 @@ class TreeNode:
                 children=filtered_children,
             )
         return None
-```
+```python
 
 ### Building the Tree
 
@@ -72,7 +72,7 @@ import numpy as np
 
 dimension = 384  # all-MiniLM-L6-v2 output dimension
 index = faiss.IndexFlatIP(dimension)
-```
+```python
 
 ### Operations
 
@@ -108,14 +108,14 @@ class ChunkMetadata:
     heading_path: list[str]
     content: str         # original text for display
     token_count: int
-```
+```text
 
 Store as JSON lines alongside the FAISS index:
 
 ```
 index.faiss          # FAISS binary index
 metadata.jsonl       # one JSON object per vector, same order
-```
+```text
 
 ## Hybrid Retrieval Pipeline
 
@@ -140,7 +140,7 @@ Query
   |
   v
 5. Rank and return (re-rank by relevance, return top-n)
-```
+```python
 
 ### Step Details
 

--- a/plugins/ralph/README.md
+++ b/plugins/ralph/README.md
@@ -12,4 +12,4 @@ UserStory → PRD → JSON pipeline and interactive user story builder for the R
 
 ```bash
 claude plugin install ralph@qte77-claude-code-plugins
-```
+```text

--- a/plugins/ralph/skills/generating-interactive-userstory-md/SKILL.md
+++ b/plugins/ralph/skills/generating-interactive-userstory-md/SKILL.md
@@ -46,4 +46,4 @@ See `ralph/docs/templates/userstory.md.template` for structure and placeholders.
 
 ```bash
 make ralph_userstory
-```
+```text

--- a/plugins/ralph/skills/generating-prd-json-from-prd-md/SKILL.md
+++ b/plugins/ralph/skills/generating-prd-json-from-prd-md/SKILL.md
@@ -18,7 +18,7 @@ Hybrid approach: Python script parses, AI validates and corrects.
 
 ```bash
 python ralph/scripts/generate_prd_json.py --dry-run
-```
+```bash
 
 Check output for: declared vs parsed story count mismatch, missing stories, empty acceptance/files. If issues found, fix PRD markdown or note for manual correction in step 3.
 
@@ -81,7 +81,7 @@ See `ralph/docs/templates/prd.json.template` for structure and fields.
 
 ```bash
 make ralph_prd_json
-```
+```bash
 
 ## Next Steps
 

--- a/plugins/readme-generator/references/readme-best-practices.md
+++ b/plugins/readme-generator/references/readme-best-practices.md
@@ -4,7 +4,7 @@
 
 **File location:** `.github/profile/README.md`
 
-**Structure (150-400 words):**
+### Structure (150-400 words):
 1. H1 + single-sentence mission
 2. Brief elaboration (2-3 sentences)
 3. Projects grouped by domain with inline links
@@ -14,7 +14,7 @@
 
 **File location:** `<username>/<username>/README.md`
 
-**Structure (under 300 words):**
+### Structure (under 300 words):
 1. Name/tagline
 2. Current focus (2-3 bullets)
 3. Featured projects (3-5 linked)
@@ -23,7 +23,7 @@
 
 ## Repository READMEs — GitHub Actions
 
-**Standard badge set (in order, below H1):**
+### Standard badge set (in order, below H1):
 1. Version — `![Version](https://img.shields.io/badge/version-X.Y.Z-8A2BE2)`
 2. License — `![License](https://img.shields.io/badge/license-Apache--2.0-blue)`
 3. GHA status — test-action workflow badge
@@ -33,7 +33,7 @@
 7. Ruff / Pytest — linter + test badges (Python actions)
 8. BATS — test framework badge (shell-based actions)
 
-**Required sections (in order):**
+### Required sections (in order):
 1. `# repo-name` + badges
 2. One-line description
 3. `## Inputs` — table: Name | Required | Default | Description
@@ -42,7 +42,7 @@
 6. `## What it does` — numbered steps
 7. `## License` — `[License-Type](LICENSE)`
 
-**Conventions:**
+### Conventions:
 - License file is always `LICENSE` (never `LICENSE.md`)
 - Input table column order: Name | Required | Default | Description
 - Pinned action SHAs in usage examples: `@<sha> # vX.Y.Z`

--- a/plugins/readme-generator/skills/auditing-readme/SKILL.md
+++ b/plugins/readme-generator/skills/auditing-readme/SKILL.md
@@ -80,7 +80,7 @@ Parse `$ARGUMENTS`:
 
 Output a findings table per target:
 
-```
+```yaml
 ## <repo-name>
 
 | # | Check | Level | Status | Notes |
@@ -91,7 +91,7 @@ Summary: X/Y required pass, Z/W recommended pass.
 
 ### Batch Summary
 
-```
+```text
 | Repo | Required | Recommended | Top Issue |
 |------|----------|-------------|-----------|
 ```

--- a/plugins/rust-dev/README.md
+++ b/plugins/rust-dev/README.md
@@ -16,4 +16,4 @@ Rust implementation, testing, and code review skills, deploys cargo permissions 
 
 ```bash
 claude plugin install rust-dev@qte77-claude-code-plugins
-```
+```text

--- a/plugins/rust-dev/skills/implementing-rust/SKILL.md
+++ b/plugins/rust-dev/skills/implementing-rust/SKILL.md
@@ -48,6 +48,6 @@ Before completing any task:
 
 ```bash
 cargo test && cargo clippy -- -D warnings && cargo fmt --check
-```
+```text
 
 All tests, lints, and formatting must pass.

--- a/plugins/rust-dev/skills/implementing-rust/references/rust-best-practices.md
+++ b/plugins/rust-dev/skills/implementing-rust/references/rust-best-practices.md
@@ -6,6 +6,8 @@ purpose: Security-first Rust coding standards with type safety and ownership pat
 see-also: testing-strategy.md, tdd-best-practices.md
 ---
 
+# Rust Best Practices
+
 ## Security (Non-Negotiable)
 
 ### No Unsafe Unless Justified
@@ -15,7 +17,7 @@ see-also: testing-strategy.md, tdd-best-practices.md
 ```rust
 // SAFETY: `ptr` is non-null and exclusively owned for the duration of this call
 unsafe { std::ptr::write(ptr, value) };
-```
+```yaml
 
 Prefer safe abstractions (`Vec`, `Box`, `Arc`) over raw pointers. Run `cargo clippy` and `cargo audit` on every build.
 
@@ -60,7 +62,7 @@ impl FromStr for Email {
         }
     }
 }
-```
+```text
 
 ## Type System
 
@@ -87,7 +89,7 @@ enum ConnectionState {
     Connected { stream: TcpStream },
     Failed { reason: String },
 }
-```
+```text
 
 ### Option and Result Instead of Null/Exceptions
 
@@ -117,7 +119,7 @@ pub enum AppError {
     #[error("invalid input: {0}")]
     InvalidInput(String),
 }
-```
+```javascript
 
 ### anyhow for Binaries
 
@@ -146,7 +148,7 @@ fn store_user(user: User) { self.users.push(user); }
 // Clone only when ownership transfer is genuinely needed
 let owned = user.name.clone();
 spawn(async move { use_owned(owned).await });
-```
+```text
 
 ## Traits
 
@@ -174,7 +176,7 @@ for item in items {
 while let Some(res) = set.join_next().await {
     handle(res?);
 }
-```
+```text
 
 ### Timeout Handling
 
@@ -203,7 +205,7 @@ async fn login(user: &User, password: &str) -> Result<Token, AppError> {
     info!(token_expiry = %token.expires_at, "login successful");
     Ok(token)
 }
-```
+```text
 
 Never use `println!` for logging in production code.
 

--- a/plugins/rust-dev/skills/reviewing-rust/references/rust-best-practices.md
+++ b/plugins/rust-dev/skills/reviewing-rust/references/rust-best-practices.md
@@ -6,6 +6,8 @@ purpose: Security-first Rust coding standards with type safety and ownership pat
 see-also: testing-strategy.md, tdd-best-practices.md
 ---
 
+# Rust Best Practices
+
 ## Security (Non-Negotiable)
 
 ### No Unsafe Unless Justified
@@ -15,7 +17,7 @@ see-also: testing-strategy.md, tdd-best-practices.md
 ```rust
 // SAFETY: `ptr` is non-null and exclusively owned for the duration of this call
 unsafe { std::ptr::write(ptr, value) };
-```
+```yaml
 
 Prefer safe abstractions (`Vec`, `Box`, `Arc`) over raw pointers. Run `cargo clippy` and `cargo audit` on every build.
 
@@ -60,7 +62,7 @@ impl FromStr for Email {
         }
     }
 }
-```
+```text
 
 ## Type System
 
@@ -87,7 +89,7 @@ enum ConnectionState {
     Connected { stream: TcpStream },
     Failed { reason: String },
 }
-```
+```text
 
 ### Option and Result Instead of Null/Exceptions
 
@@ -117,7 +119,7 @@ pub enum AppError {
     #[error("invalid input: {0}")]
     InvalidInput(String),
 }
-```
+```javascript
 
 ### anyhow for Binaries
 
@@ -146,7 +148,7 @@ fn store_user(user: User) { self.users.push(user); }
 // Clone only when ownership transfer is genuinely needed
 let owned = user.name.clone();
 spawn(async move { use_owned(owned).await });
-```
+```text
 
 ## Traits
 
@@ -174,7 +176,7 @@ for item in items {
 while let Some(res) = set.join_next().await {
     handle(res?);
 }
-```
+```text
 
 ### Timeout Handling
 
@@ -203,7 +205,7 @@ async fn login(user: &User, password: &str) -> Result<Token, AppError> {
     info!(token_expiry = %token.expires_at, "login successful");
     Ok(token)
 }
-```
+```text
 
 Never use `println!` for logging in production code.
 

--- a/plugins/rust-dev/skills/testing-rust/SKILL.md
+++ b/plugins/rust-dev/skills/testing-rust/SKILL.md
@@ -50,7 +50,7 @@ fn test_order_calculator_sums_item_prices() {
     // ASSERT
     assert_eq!(total, 25);
 }
-```
+```text
 
 ## proptest Priorities (Edge Cases within TDD)
 
@@ -87,7 +87,7 @@ cargo test test_order               # Filter by name
 cargo test --lib                    # Unit tests only
 cargo test --test integration       # Integration tests only
 cargo watch -x test                 # Watch mode (cargo-watch)
-```
+```text
 
 ## Quality Gates
 

--- a/plugins/rust-dev/skills/testing-rust/references/tdd-best-practices.md
+++ b/plugins/rust-dev/skills/testing-rust/references/tdd-best-practices.md
@@ -5,6 +5,8 @@ based-on: Industry research 2025-2026
 see-also: testing-strategy.md
 ---
 
+# TDD Best Practices
+
 **Purpose**: Rust-specific TDD examples with cargo test, proptest, and mockall.
 
 > Language-agnostic TDD principles (cycle, AAA, anti-patterns) are in
@@ -31,7 +33,7 @@ fn test_order_calculator_sums_item_prices() {
     // ASSERT
     assert_eq!(total, 25);
 }
-```
+```javascript
 
 ## Rust-Specific TDD: Newtype with Validation
 
@@ -59,7 +61,7 @@ impl Email {
         }
     }
 }
-```
+```javascript
 
 **REFACTOR** — improve without breaking tests.
 
@@ -104,7 +106,7 @@ fn test_cache_returns_stored_value() {
     cache.insert("key", "value");
     assert_eq!(cache.get("key"), Some("value"));
 }
-```
+```javascript
 
 ### unwrap() masking failures
 
@@ -139,4 +141,4 @@ cargo watch -x test                              # Watch mode
 cargo test test_email_rejects_missing_at_sign     # Single test
 cargo test -- --nocapture                         # Show output
 cargo test && cargo clippy -- -D warnings         # Pre-commit
-```
+```text

--- a/plugins/rust-dev/skills/testing-rust/references/testing-strategy.md
+++ b/plugins/rust-dev/skills/testing-rust/references/testing-strategy.md
@@ -6,6 +6,8 @@ purpose: Rust-specific testing tools and when to use each
 see-also: tdd-best-practices.md
 ---
 
+# Testing Strategy
+
 **Purpose**: Rust-specific testing tools and when to use each.
 
 > Language-agnostic testing strategy (what to test, mocking, organization)
@@ -72,7 +74,7 @@ mod tests {
         assert_eq!(add(2, 3), 5);
     }
 }
-```
+```text
 
 `#[cfg(test)]` excludes test code from release builds.
 
@@ -102,7 +104,7 @@ proptest! {
         prop_assert!(result <= max);
     }
 }
-```
+```javascript
 
 ## Snapshot Testing with insta
 
@@ -142,7 +144,7 @@ fn test_user_service_returns_not_found() {
     let service = UserService::new(mock);
     assert!(service.get_user(99).is_err());
 }
-```
+```text
 
 Always set `.times()` — unverified calls pass silently without it.
 
@@ -175,7 +177,7 @@ tests/
 test_order_calculator_sums_items()
 test_user_parser_rejects_empty_email()
 test_score_always_in_bounds()  // property test
-```
+```text
 
 ## Decision Checklist
 

--- a/plugins/security-audit/README.md
+++ b/plugins/security-audit/README.md
@@ -12,4 +12,4 @@ Code security auditing plugin with three skills for repo-wide audits. For diff-s
 
 ```bash
 claude plugin install security-audit@qte77-claude-code-plugins
-```
+```text

--- a/plugins/tdd-core/README.md
+++ b/plugins/tdd-core/README.md
@@ -15,4 +15,4 @@ Language-agnostic TDD methodology for any project.
 
 ```bash
 claude plugin install tdd-core@qte77-claude-code-plugins
-```
+```text

--- a/plugins/tdd-core/skills/testing-tdd/SKILL.md
+++ b/plugins/tdd-core/skills/testing-tdd/SKILL.md
@@ -33,7 +33,7 @@ Writes **focused, behavior-driven tests** following the TDD Red-Green-Refactor c
 
 Every test has three phases:
 
-```
+```text
 ARRANGE — Set up test data and dependencies
 ACT     — Execute the behavior under test
 ASSERT  — Verify the outcome

--- a/plugins/tdd-core/skills/testing-tdd/references/tdd-best-practices.md
+++ b/plugins/tdd-core/skills/testing-tdd/references/tdd-best-practices.md
@@ -5,6 +5,8 @@ based-on: Industry research 2025-2026, adapted from python-dev testing-python
 see-also: testing-strategy.md
 ---
 
+# TDD Best Practices
+
 **Purpose**: How to do TDD — Red-Green-Refactor cycle, AAA structure,
 best practices, anti-patterns. Language-agnostic.
 
@@ -29,7 +31,7 @@ best practices, anti-patterns. Language-agnostic.
 └─────┬───────┘
       │
       └──────> Repeat
-```
+```bash
 
 ## Core Practices
 
@@ -54,7 +56,7 @@ total = processor.calculateTotal(items)
 
 // ASSERT — Verify the outcome
 assertEqual(total, 25)
-```
+```text
 
 ### 3. Keep Tests Atomic and Isolated
 
@@ -90,7 +92,7 @@ assert(service._internalClient instanceof SomeLibrary)
 
 // GOOD — Tests behavior
 assertEqual(service.fetch("key"), expectedValue)
-```
+```text
 
 ### Untyped mocks
 

--- a/plugins/tdd-core/skills/testing-tdd/references/testing-strategy.md
+++ b/plugins/tdd-core/skills/testing-tdd/references/testing-strategy.md
@@ -6,6 +6,8 @@ purpose: High-level testing strategy aligned with KISS/DRY/YAGNI
 see-also: tdd-best-practices.md
 ---
 
+# Testing Strategy
+
 **Purpose**: What to test, test organization, mocking strategy,
 decision checklist. Language-agnostic.
 
@@ -87,7 +89,7 @@ decision checklist. Language-agnostic.
 tests/
 ├── *.test.*           # Unit tests
 └── setup.*            # Shared setup
-```
+```text
 
 **Organized structure** (larger projects):
 
@@ -102,7 +104,7 @@ tests/
 
 Name describes behavior, not method:
 
-```
+```text
 // Unit tests
 "calculates total from items"
 "returns empty array for unknown user"

--- a/plugins/typescript-dev/README.md
+++ b/plugins/typescript-dev/README.md
@@ -17,4 +17,4 @@ TypeScript implementation, testing, and code review skills, deploys npm/vitest p
 
 ```bash
 claude plugin install typescript-dev@qte77-claude-code-plugins
-```
+```text

--- a/plugins/typescript-dev/skills/implementing-typescript/SKILL.md
+++ b/plugins/typescript-dev/skills/implementing-typescript/SKILL.md
@@ -50,6 +50,6 @@ Before completing any task:
 
 ```bash
 npx tsc --noEmit && npx vitest run && npx eslint .
-```
+```text
 
 All type checks, tests, and lints must pass.

--- a/plugins/typescript-dev/skills/implementing-typescript/references/react-best-practices.md
+++ b/plugins/typescript-dev/skills/implementing-typescript/references/react-best-practices.md
@@ -6,6 +6,8 @@ purpose: Modern React patterns with functional components, hooks, and accessibil
 see-also: typescript-best-practices.md, vite-conventions.md
 ---
 
+# React Best Practices
+
 ## Components
 
 ### Functional Components Only
@@ -23,7 +25,7 @@ export function UserCard({ user, onSelect }: UserCardProps) {
     </button>
   );
 }
-```
+```javascript
 
 Always type props with an interface. Never use class components.
 
@@ -51,7 +53,7 @@ function useDebounce<T>(value: T, delay: number): T {
   }, [value, delay]);
   return debounced;
 }
-```
+```javascript
 
 ### useEffect Dependency Arrays
 
@@ -79,7 +81,7 @@ const handleSubmit = useCallback((data: FormData) => {
 
 // DON'T use for: simple values, inline functions in non-memoized components
 // Premature memoization adds complexity without benefit
-```
+```javascript
 
 ## State Management
 
@@ -107,7 +109,7 @@ async function createAction(formData: FormData) {
   'use server';
   await saveToDb(formData);
 }
-```
+```javascript
 
 ## Keys
 
@@ -131,7 +133,7 @@ async function createAction(formData: FormData) {
 
 // BAD — div soup
 <div onClick={toggle}>Menu</div>
-```
+```javascript
 
 ### Required Practices
 

--- a/plugins/typescript-dev/skills/implementing-typescript/references/typescript-best-practices.md
+++ b/plugins/typescript-dev/skills/implementing-typescript/references/typescript-best-practices.md
@@ -6,6 +6,8 @@ purpose: Type-safe TypeScript coding standards with strict mode and modern patte
 see-also: react-best-practices.md, vite-conventions.md
 ---
 
+# Typescript Best Practices
+
 ## Strict Mode (Non-Negotiable)
 
 ### tsconfig.json Essentials
@@ -22,7 +24,7 @@ see-also: react-best-practices.md, vite-conventions.md
     "skipLibCheck": true
   }
 }
-```
+```yaml
 
 All projects must use `strict: true`. Never disable individual strict checks.
 
@@ -37,7 +39,7 @@ const config = {
 function throwEnvError(name: string): never {
   throw new Error(`Missing environment variable: ${name}`);
 }
-```
+```javascript
 
 Never hardcode credentials in source code.
 
@@ -54,7 +56,7 @@ function parse(input: unknown): User {
   if (!isUser(input)) throw new TypeError('Invalid user data');
   return input;
 }
-```
+```javascript
 
 ### Type Guards Over Casts
 
@@ -78,7 +80,7 @@ type RequestState =
   | { status: 'loading' }
   | { status: 'success'; data: User[] }
   | { status: 'error'; error: string };
-```
+```javascript
 
 The compiler enforces exhaustive handling with `switch` on `status`.
 
@@ -90,7 +92,7 @@ const name = user?.profile?.displayName ?? 'Anonymous';
 
 // Use strict null checks — never assume values exist
 function getItem(id: string): Item | undefined { ... }
-```
+```javascript
 
 ## Error Handling
 
@@ -106,7 +108,7 @@ function parseConfig(raw: string): Result<Config> {
     return { ok: false, error: new Error('Invalid config JSON') };
   }
 }
-```
+```javascript
 
 ### Try/Catch (for unexpected errors)
 
@@ -128,7 +130,7 @@ export function createUser(data: UserInput): User { ... }
 export type { User, UserInput };
 
 // Avoid default exports (harder to refactor, inconsistent naming)
-```
+```python
 
 ### Import Order
 
@@ -141,7 +143,7 @@ import { z } from 'zod';
 import { createUser } from '@/services/user';
 // 4. Types
 import type { User } from '@/types';
-```
+```javascript
 
 ## Generics
 
@@ -151,7 +153,7 @@ function groupBy<T, K extends string>(items: T[], key: (item: T) => K): Record<K
 
 // Inferred generics — let TypeScript infer when possible
 const result = groupBy(users, (u) => u.role);
-```
+```javascript
 
 ## Async Patterns
 
@@ -174,7 +176,7 @@ const [user, orders, prefs] = results.map((r) =>
 ```typescript
 const controller = new AbortController();
 const res = await fetch(url, { signal: controller.signal });
-```
+```text
 
 ## Common Mistakes
 

--- a/plugins/typescript-dev/skills/implementing-typescript/references/vite-conventions.md
+++ b/plugins/typescript-dev/skills/implementing-typescript/references/vite-conventions.md
@@ -6,6 +6,8 @@ purpose: Vite project structure, configuration, and deployment conventions
 see-also: typescript-best-practices.md, react-best-practices.md
 ---
 
+# Vite Conventions
+
 ## Project Structure
 
 ```text
@@ -23,7 +25,7 @@ see-also: typescript-best-practices.md, react-best-practices.md
 ├── vite.config.ts
 ├── tsconfig.json
 └── package.json
-```
+```python
 
 ## Configuration
 
@@ -52,7 +54,7 @@ Configure in both `vite.config.ts` and `tsconfig.json`:
     "paths": { "@/*": ["./src/*"] }
   }
 }
-```
+```javascript
 
 Use `@/` prefix for all internal imports: `import { Button } from '@/components/Button'`.
 
@@ -77,7 +79,7 @@ interface ImportMetaEnv {
 .env                # Shared defaults
 .env.local          # Local overrides (gitignored)
 .env.production     # Production values
-```
+```yaml
 
 Never prefix secrets with `VITE_` — they are embedded in the client bundle.
 
@@ -97,7 +99,7 @@ export default defineConfig({
 ```bash
 npx vite build          # Output to dist/
 npx vite preview        # Preview production build locally
-```
+```python
 
 ## Tailwind CSS v4 (Vite Plugin)
 
@@ -113,7 +115,7 @@ export default defineConfig({
 ```css
 /* src/index.css — v4 uses @import instead of @tailwind directives */
 @import 'tailwindcss';
-```
+```text
 
 No `tailwind.config.js` needed in v4 — configure via CSS `@theme`.
 

--- a/plugins/typescript-dev/skills/testing-typescript/SKILL.md
+++ b/plugins/typescript-dev/skills/testing-typescript/SKILL.md
@@ -49,7 +49,7 @@ it('calculates order total from item prices', () => {
   // ASSERT
   expect(total).toBe(25);
 });
-```
+```javascript
 
 ## Component Testing Priorities
 
@@ -87,7 +87,7 @@ npx vitest run                      # Single run
 npx vitest run src/utils            # Filter by path
 npx vitest run --reporter=verbose   # Verbose output
 npx vitest --ui                     # Browser UI
-```
+```text
 
 ## Quality Gates
 

--- a/plugins/typescript-dev/skills/testing-typescript/references/testing-strategy-ts.md
+++ b/plugins/typescript-dev/skills/testing-typescript/references/testing-strategy-ts.md
@@ -6,6 +6,8 @@ purpose: TypeScript-specific testing tools and when to use each
 see-also: tdd-best-practices-ts.md
 ---
 
+# Testing Strategy TS
+
 **Purpose**: TypeScript-specific testing tools and when to use each.
 
 > Language-agnostic testing strategy (what to test, mocking, organization)
@@ -70,7 +72,7 @@ describe('calculateTotal', () => {
     expect(calculateTotal(items)).toBe(25);
   });
 });
-```
+```python
 
 ## Component Tests with @testing-library/react
 
@@ -106,7 +108,7 @@ await screen.findByText('Loaded');
 await waitFor(() => {
   expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
 });
-```
+```python
 
 ## API Mocking with MSW
 
@@ -136,7 +138,7 @@ import { vi, describe, it, expect } from 'vitest';
 vi.mock('./api', () => ({
   fetchUser: vi.fn().mockResolvedValue({ id: '1', name: 'Alice' }),
 }));
-```
+```python
 
 Always call `vi.restoreAllMocks()` in `afterEach`.
 
@@ -158,7 +160,7 @@ export default defineConfig({
 ```typescript
 // src/test/setup.ts
 import '@testing-library/jest-dom/vitest';
-```
+```text
 
 ## Test Organization
 
@@ -184,7 +186,7 @@ describe('OrderCalculator', () => {
   it('sums item prices', () => { ... });
   it('applies percentage discount', () => { ... });
 });
-```
+```text
 
 ## Decision Checklist
 

--- a/plugins/website-audit/README.md
+++ b/plugins/website-audit/README.md
@@ -14,7 +14,7 @@ Try it out after installing:
 
 ```text
 /auditing-website-accessibility https://example.com
-```
+```bash
 
 This will run a WCAG 2.1 AA compliance audit against the target URL,
 producing findings with severity levels and implementable code fixes.

--- a/plugins/website-audit/skills/researching-website-design/SKILL.md
+++ b/plugins/website-audit/skills/researching-website-design/SKILL.md
@@ -40,7 +40,7 @@ never seen a website?"
 1. [Company] - [URL] - Authority: [H/M/L]
    Cites: [Studies/sources referenced]
    Cross-refs: [Shared sources with other sites]
-```
+```yaml
 
 ### Design Breakthroughs (Max 3)
 
@@ -59,7 +59,7 @@ COLORS: Primary #HEX [effect], Accent #HEX [effect]
 TYPOGRAPHY: Headers [font/weight], Body [font/size]
 HEADLINES: "[Pattern]" - [User psychology]
 CTAS: "[Button text]" - [Action driver]
-```
+```yaml
 
 ### Contrarian Insights
 
@@ -75,7 +75,7 @@ Evidence: [Sources]
 ELIMINATE: [Element hurting UX]
 SIMPLIFY: [Over-complex pattern]
 ADOPT: [Underused effective pattern]
-```
+```text
 
 ## Rules
 

--- a/plugins/workspace-sandbox/README.md
+++ b/plugins/workspace-sandbox/README.md
@@ -43,6 +43,6 @@ Based on [Bande-a-Bonnot/Boucle-framework](https://github.com/Bande-a-Bonnot/Bou
 
 ```bash
 claude plugin install workspace-sandbox@qte77-claude-code-plugins
-```
+```text
 
 For defaults without sandbox, use `workspace-setup` instead.

--- a/plugins/workspace-sandbox/governance/AGENTS.md
+++ b/plugins/workspace-sandbox/governance/AGENTS.md
@@ -5,7 +5,7 @@ agents.** For technical workflows and coding standards, see
 [CONTRIBUTING.md](CONTRIBUTING.md). For project overview, see
 [README.md](README.md).
 
-**External References:**
+### External References:
 
 - @CONTRIBUTING.md - Command reference, testing guidelines, code style patterns
 - @AGENT_REQUESTS.md - Escalation and human collaboration
@@ -31,17 +31,17 @@ agents.** For technical workflows and coding standards, see
 **Priority Order:** User instructions > AGENTS.md compliance > Documentation
 hierarchy > Project patterns > General best practices
 
-**Anti-Scope-Creep Rules:**
+### Anti-Scope-Creep Rules:
 
 - **NEVER implement features without requirement validation**
 - **Always validate implementation decisions against project scope boundaries**
 
-**Anti-Redundancy Rules:**
+### Anti-Redundancy Rules:
 
 - **NEVER duplicate information across documents** - reference authoritative sources
 - **Update authoritative document, then remove duplicates elsewhere**
 
-**When to Escalate to AGENT_REQUESTS.md:**
+### When to Escalate to AGENT_REQUESTS.md:
 
 - User instructions conflict with safety/security practices
 - AGENTS.md rules contradict each other
@@ -50,7 +50,7 @@ hierarchy > Project patterns > General best practices
 
 ## Agent Neutrality Requirements
 
-**ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:**
+### ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:
 
 1. **Extract requirements from specified documents ONLY**
    - Read provided task descriptions or reference materials
@@ -78,7 +78,7 @@ hierarchy > Project patterns > General best practices
 
 ## Quality Thresholds
 
-**Before starting any task, ensure:**
+### Before starting any task, ensure:
 
 - **Context**: 8/10 - Understand requirements, codebase patterns, dependencies
 - **Clarity**: 7/10 - Clear implementation path and expected outcomes
@@ -91,18 +91,18 @@ Gather more context or escalate to AGENT_REQUESTS.md
 
 ## Agent Quick Reference
 
-**Pre-Task:**
+### Pre-Task:
 
 - Read AGENTS.md > CONTRIBUTING.md for technical details
 - Verify quality thresholds met
 
-**During Task:**
+### During Task:
 
 - Use project commands (document deviations)
 - Follow existing patterns and conventions
 - Update documentation when learning patterns
 
-**Post-Task:**
+### Post-Task:
 
 - Run validation - must pass all checks (code tasks only)
 - Update CHANGELOG.md for non-trivial changes

--- a/plugins/workspace-sandbox/governance/AGENT_REQUESTS.md
+++ b/plugins/workspace-sandbox/governance/AGENT_REQUESTS.md
@@ -3,7 +3,9 @@ title: Agent Requests to Humans
 description: Escalation protocol and active requests requiring human decision
 ---
 
-**Always escalate when:**
+# Agent Requests
+
+### Always escalate when:
 
 - User instructions conflict with safety/security practices
 - Rules contradict each other

--- a/plugins/workspace-setup/README.md
+++ b/plugins/workspace-setup/README.md
@@ -33,6 +33,6 @@ Based on [Bande-a-Bonnot/Boucle-framework](https://github.com/Bande-a-Bonnot/Bou
 
 ```bash
 claude plugin install workspace-setup@qte77-claude-code-plugins
-```
+```text
 
 For sandbox settings, use `workspace-sandbox` instead.

--- a/plugins/workspace-setup/governance/AGENTS.md
+++ b/plugins/workspace-setup/governance/AGENTS.md
@@ -5,7 +5,7 @@ agents.** For technical workflows and coding standards, see
 [CONTRIBUTING.md](CONTRIBUTING.md). For project overview, see
 [README.md](README.md).
 
-**External References:**
+### External References:
 
 - @CONTRIBUTING.md - Command reference, testing guidelines, code style patterns
 - @AGENT_REQUESTS.md - Escalation and human collaboration
@@ -31,17 +31,17 @@ agents.** For technical workflows and coding standards, see
 **Priority Order:** User instructions > AGENTS.md compliance > Documentation
 hierarchy > Project patterns > General best practices
 
-**Anti-Scope-Creep Rules:**
+### Anti-Scope-Creep Rules:
 
 - **NEVER implement features without requirement validation**
 - **Always validate implementation decisions against project scope boundaries**
 
-**Anti-Redundancy Rules:**
+### Anti-Redundancy Rules:
 
 - **NEVER duplicate information across documents** - reference authoritative sources
 - **Update authoritative document, then remove duplicates elsewhere**
 
-**When to Escalate to AGENT_REQUESTS.md:**
+### When to Escalate to AGENT_REQUESTS.md:
 
 - User instructions conflict with safety/security practices
 - AGENTS.md rules contradict each other
@@ -50,7 +50,7 @@ hierarchy > Project patterns > General best practices
 
 ## Agent Neutrality Requirements
 
-**ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:**
+### ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:
 
 1. **Extract requirements from specified documents ONLY**
    - Read provided task descriptions or reference materials
@@ -78,7 +78,7 @@ hierarchy > Project patterns > General best practices
 
 ## Quality Thresholds
 
-**Before starting any task, ensure:**
+### Before starting any task, ensure:
 
 - **Context**: 8/10 - Understand requirements, codebase patterns, dependencies
 - **Clarity**: 7/10 - Clear implementation path and expected outcomes
@@ -91,18 +91,18 @@ Gather more context or escalate to AGENT_REQUESTS.md
 
 ## Agent Quick Reference
 
-**Pre-Task:**
+### Pre-Task:
 
 - Read AGENTS.md > CONTRIBUTING.md for technical details
 - Verify quality thresholds met
 
-**During Task:**
+### During Task:
 
 - Use project commands (document deviations)
 - Follow existing patterns and conventions
 - Update documentation when learning patterns
 
-**Post-Task:**
+### Post-Task:
 
 - Run validation - must pass all checks (code tasks only)
 - Update CHANGELOG.md for non-trivial changes

--- a/plugins/workspace-setup/governance/AGENT_REQUESTS.md
+++ b/plugins/workspace-setup/governance/AGENT_REQUESTS.md
@@ -3,7 +3,9 @@ title: Agent Requests to Humans
 description: Escalation protocol and active requests requiring human decision
 ---
 
-**Always escalate when:**
+# Agent Requests
+
+### Always escalate when:
 
 - User instructions conflict with safety/security practices
 - Rules contradict each other


### PR DESCRIPTION
## Summary
- Bump `lint-md-links.yml` `uses:` SHA pin to current `qte77/.github` main (2026-04-27, includes #20 schedule-skip-md and #21 cli2 docs)
- Apply markdown inference fixes for canonical lint compliance (where applicable):
  - MD040 (fence language) inferred from block content (bash/python/json/yaml/text)
  - MD041 (first-line H1) inferred from filename
  - MD025 (multiple H1s) demoted to H2
  - MD036 (emphasis-as-heading) converted to H3

Generated with Claude <noreply@anthropic.com>