### PR TITLE
ci(issues): add AI issue-triage via qte77/gha-issue-triage@v0.2.4

### DIFF
--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -1,0 +1,39 @@
+# AI-powered issue triage via qte77/gha-issue-triage. Fires on every new,
+# edited, or reopened issue. Detects duplicates, scores relevance against
+# the repo's scope (README/AGENTS), analyzes feasibility + complexity,
+# auto-labels, and posts a single sticky summary comment that is edited
+# in place on re-runs.
+#
+# Backend defaults to GitHub Models via the workflow's GITHUB_TOKEN —
+# `permissions: models: read` is the load-bearing line. No external API
+# key required.
+#
+# Security note: no `run:` steps consume issue-controlled fields. The only
+# template expressions used are `github.event.issue.number` (numeric, safe
+# to interpolate in the concurrency key) and `secrets.GITHUB_TOKEN`. All
+# issue body/title parsing happens inside the pinned action.
+name: issue-triage
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  models: read
+
+concurrency:
+  # One in-flight triage per issue so a quick edit doesn't race with the
+  # initial open and stack two summary comments before the sticky-edit
+  # logic kicks in. `issue.number` is numeric — safe to interpolate.
+  group: issue-triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: qte77/gha-issue-triage@cc8f0cf99014af906ea3ad1ee977d92852069579  # v0.2.4
+        with:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/issue-triage.yaml` — AI-powered issue triage via composite action `qte77/gha-issue-triage@v0.2.4`, SHA-pinned to `cc8f0cf99014af906ea3ad1ee977d92852069579`.
- Backend defaults to **GitHub Models** through the workflow's `GITHUB_TOKEN` (`permissions: models: read` is the load-bearing line). No external API key required.
- Per-issue concurrency with `cancel-in-progress: true` collapses edit bursts to one final run.

## What it does (per fire)

- Fuzzy-matches the new/edited issue against open issues (duplicate detection).
- Scores relevance 0–10 vs. repo scope (read from `README.md` + `CLAUDE.md`/`AGENTS.md`).
- Judges feasibility (yes/no) + complexity (low/medium/high).
- Auto-labels: `duplicate`, `bug`, `feature`, `enhancement`, `good-first-issue`, `needs-discussion`, `invalid` (additive — never removes existing labels).
- Posts a single sticky summary comment, edited in place on re-runs.

## Security notes

- No `run:` steps consume user-controlled fields. Only template expressions are `github.event.issue.number` (numeric, safe to interpolate in the concurrency key) and `secrets.GITHUB_TOKEN`. All issue body/title parsing happens inside the pinned action.
- Action is pinned to a full 40-char SHA; tag dereference verified (`v0.2.4` is a lightweight tag → commit `cc8f0cf...`).

## Test plan

- [ ] CI green on this PR.
- [ ] Post-merge: open a throwaway test issue, confirm workflow run completes `<10s`, sticky `### AI triage summary` comment posted, additive labels applied.
- [ ] Delete the test issue on success.

## Followup (optional, not in this PR)

- Pre-create the bot's label set (`bug`, `feature`, `enhancement`, `duplicate`, `good-first-issue`, `needs-discussion`, `invalid`) to avoid the bot auto-creating duplicates of GitHub's default `good first issue` (with spaces).

🤖 Generated with Claude <noreply@anthropic.com>