### PR TITLE
feat(readme-generator): add batch README audit dynamic workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -165,7 +165,7 @@
       "name": "readme-generator",
       "source": "./plugins/readme-generator",
       "description": "Generate and audit README.md files for repos, GitHub accounts, and organizations",
-      "version": "1.0.1"
+      "version": "1.1.0"
     },
     {
       "name": "planning",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **cc-meta**: `subagent transcripts` as `synthesizing-cc-bigpicture` data source; workflow updated with dedicated bullet (#98)
 - **cc-meta**: 4-tier progressive retrieval for `synthesizing-cc-bigpicture` (metadata → summaries → deep reads → full scan) in `references/progressive-retrieval.md` (#99)
 - **codebase-tools**: `hardening-codebase` skill — 7-phase quality tightening workflow (audit → tighten → fix → tests → review → refactor → ship) with language-specific lint progressions and 3-agent review framework (#102)
+- **readme-generator**: `auditing-readme` batch `repos` scope can now drive a bundled dynamic workflow (`workflows/audit-repos.js`) — fans the README checklist across many repos in parallel via `Workflow({scriptPath, args})`, then runs one cross-repo consistency pass. The skill gates to the workflow when the Workflow tool is available and falls back to the inline per-repo loop otherwise; workflow agents are read-only. First demonstration that a marketplace plugin can ship a dynamic workflow (referenced by `scriptPath`, since `workflows/` is not a plugin component). Plugin version 1.0.1 → 1.1.0 (#162)
 
 #### New agents (#38-#112)
 

--- a/plugins/readme-generator/.claude-plugin/plugin.json
+++ b/plugins/readme-generator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-generator",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Generate and audit README.md files for repos, GitHub accounts, and organizations",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["readme", "profile", "organization", "github", "documentation", "audit"]

--- a/plugins/readme-generator/skills/auditing-readme/SKILL.md
+++ b/plugins/readme-generator/skills/auditing-readme/SKILL.md
@@ -23,6 +23,29 @@ Parse `$ARGUMENTS`:
 - `account <username>` — audit a GitHub user profile README
 - `org <orgname>` — audit an organization profile README
 
+## Workflow Mode (batch `repos` scope)
+
+When scope is `repos` with **more than ~3 targets** and the **Workflow tool is available**,
+fan the audit out in parallel instead of looping turn-by-turn:
+
+1. Resolve the glob to a concrete list: `gh repo list <owner> --json nameWithOwner`, filtered by pattern.
+2. Drive the bundled workflow (its instruction to call Workflow is the opt-in — no `ultracode` needed):
+
+   ```
+   Workflow({
+     scriptPath: "${CLAUDE_PLUGIN_ROOT}/workflows/audit-repos.js",
+     args: { repos: ["owner/a", "owner/b"],
+             skillPath: "${CLAUDE_PLUGIN_ROOT}/skills/auditing-readme/SKILL.md" }
+   })
+   ```
+
+   `args` is delivered to the script as a JSON string (the script parses it). Alternatively pass
+   `{ owner, pattern, skillPath }` and let the workflow's Discover phase resolve the list.
+3. Render the returned `perRepo` findings and `consistency` observations with the Phase 4 format.
+
+Fall back to the inline Phases 2–4 (one repo at a time) when the Workflow tool is unavailable.
+The workflow's agents are **read-only**, so the only permission to pre-grant is the Workflow tool.
+
 ## Phase 2: Fetch READMEs
 
 - Local repos: read README.md directly

--- a/plugins/readme-generator/workflows/audit-repos.js
+++ b/plugins/readme-generator/workflows/audit-repos.js
@@ -1,0 +1,102 @@
+export const meta = {
+  name: 'readme-audit-repos',
+  description: 'Batch README audit: fan a per-repo checklist across many repos in parallel, then cross-check consistency.',
+  phases: [
+    { title: 'Discover', detail: 'resolve owner/pattern to a repo list (skipped when repos are passed explicitly)' },
+    { title: 'Audit', detail: 'one read-only agent per repo runs the SKILL.md checklist' },
+    { title: 'Consistency', detail: 'one agent cross-checks convention drift across all repos' },
+  ],
+}
+
+// `args` arrives as a JSON string on the skill->Workflow path — parse defensively.
+const a = typeof args === 'string' ? JSON.parse(args) : (args ?? {})
+
+// Single source of truth for the checklist is the SKILL.md; agents read it when a
+// resolved path is passed in. Falls back to general README best practices otherwise.
+const skillPath = a.skillPath || ''
+const checklistRef = skillPath
+  ? `Read the audit checklist tables (Base Repo R1-R7, GHA Extension G1-G5) from ${skillPath} and apply them verbatim.`
+  : 'Apply the standard Base Repo checklist (title, description, badges, install/usage, license, valid internal links, LICENSE filename) plus a GHA inputs/outputs/usage check when action.yml or action.yaml exists.'
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  required: ['repo', 'isGHA', 'checks', 'requiredPass', 'recommendedPass', 'topIssue'],
+  properties: {
+    repo: { type: 'string' },
+    isGHA: { type: 'boolean' },
+    checks: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'level', 'status'],
+        properties: {
+          id: { type: 'string' },
+          level: { 'enum': ['required', 'recommended'] },
+          status: { 'enum': ['pass', 'fail', 'na'] },
+          note: { type: 'string' },
+        },
+      },
+    },
+    requiredPass: { type: 'string' },     // "X/Y"
+    recommendedPass: { type: 'string' },  // "Z/W"
+    topIssue: { type: 'string' },         // worst failing required check, or "none"
+  },
+}
+
+// Phase 1 — resolve the concrete repo list.
+phase('Discover')
+let repos = Array.isArray(a.repos) ? a.repos.filter(Boolean) : []
+if (!repos.length && a.owner) {
+  const pattern = a.pattern || '*'
+  const discovered = await agent(
+    `List GitHub repositories owned by "${a.owner}" whose name matches the glob "${pattern}" (treat * as wildcard). ` +
+    `Run read-only: gh repo list ${a.owner} --no-archived --limit 200 --json name,nameWithOwner. ` +
+    `Return the matching repos as full "owner/name" strings. Do not modify anything.`,
+    {
+      label: 'discover-repos',
+      phase: 'Discover',
+      schema: { type: 'object', required: ['repos'], properties: { repos: { type: 'array', items: { type: 'string' } } } },
+    },
+  )
+  repos = (discovered && discovered.repos) || []
+}
+
+if (!repos.length) {
+  log('No targets — pass args.repos: ["owner/repo", ...] or args.owner + args.pattern.')
+  return { repos: [], perRepo: [], consistency: [], note: 'no-targets' }
+}
+log(`Auditing ${repos.length} repo(s): ${repos.join(', ')}`)
+
+// Phase 2 — fan out one read-only audit agent per repo.
+phase('Audit')
+const perRepo = (await parallel(repos.map(repo => () =>
+  agent(
+    `Audit the README.md of GitHub repo "${repo}" against the readme-generator checklist. ${checklistRef}\n` +
+    `Fetch the README read-only: gh api repos/${repo}/contents/README.md --jq '.content' | base64 -d. ` +
+    `Detect GHA by probing for action.yml/action.yaml via gh api repos/${repo}/contents/<file>. ` +
+    `Evaluate every applicable check with status pass/fail/na and a short note; compute requiredPass and ` +
+    `recommendedPass as "X/Y" counts; set topIssue to the single most important failing required check (or "none"). ` +
+    `Strictly read-only — never modify any file or repo.`,
+    { label: `audit:${repo}`, phase: 'Audit', schema: FINDINGS_SCHEMA },
+  )
+))).filter(Boolean)
+
+if (!perRepo.length) {
+  return { repos, perRepo: [], consistency: [], note: 'all-audits-failed' }
+}
+
+// Phase 3 — one cross-repo consistency pass (the genuinely cross-cutting reasoning).
+phase('Consistency')
+const consistency = await agent(
+  `README audit findings across ${perRepo.length} repos:\n${JSON.stringify(perRepo)}\n\n` +
+  `Report cross-repo CONSISTENCY drift only (not per-repo issues): (1) input-table column order, ` +
+  `(2) badge style/placement, (3) section naming, (4) license format (LICENSE vs LICENSE.md). ` +
+  `Each observation must name the repos that diverge. Read-only.`,
+  {
+    label: 'consistency',
+    phase: 'Consistency',
+    schema: { type: 'object', required: ['observations'], properties: { observations: { type: 'array', items: { type: 'string' } } } },
+  },
+)
+
+return { repos, perRepo, consistency: (consistency && consistency.observations) || [] }


### PR DESCRIPTION
# Summary

Adds the first **plugin-bundled dynamic workflow** to the marketplace. The
`readme-generator` plugin's `auditing-readme` skill can now fan its README
checklist across many repos in parallel instead of looping turn-by-turn.

- New `plugins/readme-generator/workflows/audit-repos.js` — a dynamic-workflow
  script: `Discover` (resolve `owner/pattern` → repo list, skipped when an
  explicit list is passed) → `Audit` (`parallel()` one **read-only** agent per
  repo, structured findings) → `Consistency` (one cross-repo drift pass).
- `auditing-readme/SKILL.md` gains a **Workflow Mode** section: batch `repos`
  scope with >~3 targets drives the workflow via
  `Workflow({ scriptPath: "${CLAUDE_PLUGIN_ROOT}/workflows/audit-repos.js", args })`
  when the Workflow tool is available, and falls back to the inline per-repo
  loop otherwise.

**Why `scriptPath` and not a manifest entry:** `workflows/` is *not* a recognized
plugin component (verified against the plugins reference — components are skills,
agents, hooks, MCP, LSP, monitors, themes). So the skill ships the script as a
plain bundled file and drives it by absolute path. A skill whose instructions
tell Claude to call Workflow is itself a documented opt-in, so this works with
`ultracode` off. Validated end-to-end with a zero-agent `scriptPath` probe; the
one gotcha — `args` arrives as a JSON string — is handled by a defensive parse
at the top of the script.

Closes N/A

## Type of Change

- [x] `feat` — new feature (plugin, skill, hook, command)
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no functional change
- [ ] `ci` — CI/CD changes
- [ ] `chore` — tooling, config, maintenance
- [ ] `style` — formatting, whitespace (no logic change)
- [ ] `revert` — reverts a previous commit
- [ ] **Breaking change** — add `!` after commit type

## Self-Review

- [x] I have reviewed my own diff and removed debug/dead code
- [x] Commit messages follow `.gitmessage` format: `type[(scope)][!]: description`

## Testing

- [x] `make validate` passes (plugin structure + JSON syntax)
- [x] `make test_install` passes (all plugins install standalone, no broken symlinks)
- [x] `make check_sync` passes (shared references in sync with SoT)

Additionally validated the workflow artifact loads and runs in the real runtime
(`Workflow({ scriptPath })`, zero agents, `no-targets` early return).

## Documentation

- [x] `CHANGELOG.md` updated under `## [Unreleased]` → `### Added`
- [ ] `AGENT_LEARNINGS.md` — intentionally skipped: per `compound-learning`, 1st
  occurrence is fixed inline (the SKILL.md Workflow Mode section captures the
  `args`-string gotcha). Promote on recurrence (e.g. wiring `security-audit`).
- [ ] Plugin README — N/A, `readme-generator` ships no `README.md`

🤖 Generated with Claude
