### PR TITLE
feat(website-audit): SEO/GEO audit skill + WCAG 2.2 bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code utility plugins for development, architecture, auditing, documentation, market research, and CC meta-skills",
-    "version": "3.6.0"
+    "version": "3.7.0"
   },
   "plugins": [
     {
@@ -53,8 +53,8 @@
     {
       "name": "website-audit",
       "source": "./plugins/website-audit",
-      "description": "Website design research, usability audit, and WCAG accessibility audit skills",
-      "version": "1.0.2"
+      "description": "Website SEO/GEO, design research, usability, and WCAG accessibility audit skills",
+      "version": "1.1.0"
     },
     {
       "name": "docs-generator",

--- a/plugins/website-audit/.claude-plugin/plugin.json
+++ b/plugins/website-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "website-audit",
-  "version": "1.0.2",
-  "description": "Website design research, usability audit, and WCAG accessibility audit skills",
+  "version": "1.1.0",
+  "description": "Website SEO/GEO, design research, usability, and WCAG accessibility audit skills",
   "author": { "name": "Claude Code Utils Contributors" },
-  "keywords": ["website", "design", "usability", "accessibility", "wcag", "ux"]
+  "keywords": ["website", "seo", "geo", "ai-search", "design", "usability", "accessibility", "wcag", "ux"]
 }

--- a/plugins/website-audit/skills/auditing-website-accessibility/SKILL.md
+++ b/plugins/website-audit/skills/auditing-website-accessibility/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: auditing-website-accessibility
-description: Audits website accessibility for WCAG 2.1 AA compliance, generating findings and code fixes. Use when reviewing accessibility, keyboard navigation, screen reader compatibility, or inclusive design.
+description: Audits website accessibility for WCAG 2.2 AA compliance, generating findings and code fixes. Use when reviewing accessibility, keyboard navigation, screen reader compatibility, or inclusive design.
 compatibility: Designed for Claude Code
 metadata:
   allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch
   argument-hint: [url-or-file-path]
   stability: stable
-  content-hash: sha256:cfa2bbf458a6ad84cdd89cddbe69e4862cf20e2f320d3675df2b40554cf7cd9f
+  content-hash: sha256:74f858aeef05a3248b1ec5f9d9a36d4867c364e3150c262879e1593a3302e47b
   last-verified-cc-version: 1.0.34
 ---
 
@@ -14,7 +14,7 @@ metadata:
 
 **Target**: $ARGUMENTS
 
-Conducts focused accessibility audits against WCAG 2.1 AA and generates
+Conducts focused accessibility audits against WCAG 2.2 AA and generates
 implementable code fixes. No over-analysis.
 
 ## WCAG Quick Reference
@@ -90,8 +90,8 @@ Group fixes by: Keyboard Navigation, Screen Readers, Visual, Forms/Tables.
 
 ## Further Reading
 
-- [WCAG 2.1 Specification](https://www.w3.org/TR/WCAG21/)
-- [Understanding WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/)
-- [WCAG Techniques](https://www.w3.org/WAI/WCAG21/Techniques/)
+- [WCAG 2.2 Specification](https://www.w3.org/TR/WCAG22/)
+- [Understanding WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/)
+- [WCAG Techniques](https://www.w3.org/WAI/WCAG22/Techniques/)
 - [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
 - [axe-core Rules](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)

--- a/plugins/website-audit/skills/auditing-website-accessibility/references/wcag-quick-reference.md
+++ b/plugins/website-audit/skills/auditing-website-accessibility/references/wcag-quick-reference.md
@@ -1,7 +1,8 @@
-# WCAG 2.1 AA Quick Reference
+# WCAG 2.2 AA Quick Reference
 
-Condensed checklist for auditing against WCAG 2.1 Level A and AA success
-criteria. Organized by principle (POUR).
+Condensed checklist for auditing against WCAG 2.2 Level A and AA success
+criteria. Organized by principle (POUR). WCAG 2.2 adds the criteria marked
+"new in 2.2" below and removes 4.1.1 Parsing (now obsolete).
 
 ## 1. Perceivable
 
@@ -70,6 +71,8 @@ criteria. Organized by principle (POUR).
 - **2.4.5 Multiple Ways** (AA) — Multiple paths to pages (nav, search, sitemap)
 - **2.4.6 Headings and Labels** (AA) — Headings and labels are descriptive
 - **2.4.7 Focus Visible** (AA) — Keyboard focus indicator is visible
+- **2.4.11 Focus Not Obscured (Minimum)** (AA, new in 2.2) — Focused element
+  not entirely hidden by sticky headers/footers
 
 ### Input Modalities (2.5)
 
@@ -80,6 +83,10 @@ criteria. Organized by principle (POUR).
 - **2.5.3 Label in Name** (A) — Accessible name contains visible label text
 - **2.5.4 Motion Actuation** (A) — Motion-triggered actions have UI
   alternatives
+- **2.5.7 Dragging Movements** (AA, new in 2.2) — Drag actions have a
+  single-pointer alternative
+- **2.5.8 Target Size (Minimum)** (AA, new in 2.2) — Targets at least
+  24x24 CSS px, or have adequate spacing
 
 ## 3. Understandable
 
@@ -95,6 +102,8 @@ criteria. Organized by principle (POUR).
 - **3.2.2 On Input** (A) — Input doesn't trigger unexpected context change
 - **3.2.3 Consistent Navigation** (AA) — Navigation consistent across pages
 - **3.2.4 Consistent Identification** (AA) — Same function = same label
+- **3.2.6 Consistent Help** (A, new in 2.2) — Help mechanisms appear in a
+  consistent order across pages
 
 ### Input Assistance (3.3)
 
@@ -103,6 +112,10 @@ criteria. Organized by principle (POUR).
 - **3.3.3 Error Suggestion** (AA) — Suggested corrections for errors
 - **3.3.4 Error Prevention (Legal/Financial)** (AA) — Submissions
   reversible, checked, or confirmed
+- **3.3.7 Redundant Entry** (A, new in 2.2) — Don't ask for the same
+  information twice in a process
+- **3.3.8 Accessible Authentication (Minimum)** (AA, new in 2.2) — No
+  cognitive-function test without an alternative
 
 ## 4. Robust
 

--- a/plugins/website-audit/skills/auditing-website-seo-geo/SKILL.md
+++ b/plugins/website-audit/skills/auditing-website-seo-geo/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: auditing-website-seo-geo
+description: Audits a site's SEO and AI-search (GEO) readiness — meta tags, Open Graph/Twitter, JSON-LD, robots/llms conventions — and generates fixes. Use when reviewing search visibility, social previews, structured data, or LLM/AI-crawler discoverability.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch
+  argument-hint: [url-or-file-path]
+  stability: stable
+  content-hash: sha256:6fc16d33ad7c663af30e578ac2b6fe93b1737781ec4df878ac84c2a52ff3515b
+  last-verified-cc-version: 1.0.34
+---
+
+# Website SEO & GEO Audit
+
+**Target**: $ARGUMENTS
+
+Audits a site for traditional SEO and Generative-Engine Optimization (GEO —
+visibility in AI search such as ChatGPT, Perplexity, Gemini, and Google AI
+Overviews) and generates implementable fixes. Prefer configuring the site or
+static-site generator so tags are emitted once (DRY) over hand-stuffing meta
+into every page. No over-analysis.
+
+## Audit Areas
+
+### Core meta
+
+- `<title>` (~30-60 chars, unique per page), `<meta name="description">`
+  (~120-160 chars, entity-clear), `lang` on `<html>`, `charset`, `viewport`
+  (no `maximum-scale` — it blocks zoom), `robots`, `author`, `keywords`,
+  `format-detection`, and a `canonical` link.
+
+### Open Graph & Twitter Card
+
+- `og:title`, `og:description`, `og:url`, `og:type`, `og:site_name`, `og:image`.
+- `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`,
+  `twitter:site`, `twitter:creator`.
+
+### Structured data (JSON-LD)
+
+- `WebSite` / `Organization` (name, url, logo, sameAs) and per-page
+  `Article` / `BlogPosting` (headline, description, datePublished, author,
+  publisher, image). Validate against the matching schema.org type.
+
+### GEO / AI-search
+
+- `robots.txt` AI user-agents (GPTBot, ClaudeBot, Google-Extended, CCBot,
+  PerplexityBot, OAI-SearchBot) — the highest-leverage, best-honored lever.
+- `llms.txt` at root — cheap, uncertain adoption; fine to keep.
+- Entity clarity, key info in the first ~160 chars, Q&A-friendly phrasing,
+  explicit brand / product / service names.
+
+## Static-site-generator pitfalls (verify, do not assume)
+
+- **Do not double-emit.** If an SSG plugin emits OG/Twitter/JSON-LD (e.g.
+  jekyll-seo-tag, Next SEO), do NOT also hand-write those tags — duplicates
+  result. Configure the plugin instead.
+- **Plugins emit conditionally.** Twitter Card tags often need a configured
+  handle; `twitter:description` and `og:image` / `twitter:image` may not be
+  emitted without explicit config or a per-page image. Fill only the genuine
+  gaps in a single shared include.
+
+## Known-unwinnable conflicts (flag, do not chase)
+
+Some checkers want mutually-exclusive lengths on a single shared tag:
+
+- `og:title` 25-35 vs `twitter:title` 50-70 — same tag, cannot satisfy both.
+- `og:description` 55-65 vs `<meta name="description">` 120-160 — same tag.
+
+Recommend the real-world optimum (Google limits plus GEO: a ~50-char title and
+a ~150-char description) and note the tradeoff rather than ping-ponging.
+
+## Reality check
+
+- **ai.txt / `/.well-known/ai.txt`** is not a recognized standard (competing
+  vendor proposals, no IANA `.well-known` registration, no major adopter).
+  Skip it; do not spend effort on `/.well-known/ai.txt`.
+- A complete `robots.txt` AI-agent policy plus a full OG/JSON-LD set are what
+  actually move GEO and social previews.
+
+## Workflow
+
+1. **Identify scope** from $ARGUMENTS (URL, file, or directory). For a URL,
+   fetch the rendered `<head>` — converting tools return markdown, so fetch
+   raw HTML when you need the tags verbatim.
+2. **Inventory** the tags present versus the audit areas above; detect
+   duplicates.
+3. **Classify** findings: HIGH (title, description, canonical, OG core),
+   MEDIUM (Twitter, JSON-LD, keywords), LOW (format-detection, author).
+4. **Generate fixes** — prefer SSG config plus a single shared include over
+   per-page tags.
+5. **Verify** by re-fetching the built output, not the raw templates.
+
+## Output Format
+
+### Findings
+
+```text
+HIGH
+- [Tag/issue] - Current: [value or "missing"] - Page: [url/path]
+  Fix: [code/config snippet]
+
+MEDIUM / LOW
+- [Tag/issue] - Current: [value or "missing"]
+  Fix: [code/config snippet]
+```
+
+### Implementation Checklist
+
+```text
+- [ ] [Fix] - Impact: [High/Medium/Low] - scope: [site-wide | per-page]
+```
+
+## Rules
+
+- Configure once (DRY); do not hand-stuff tags an SSG already emits.
+- Flag mutually-exclusive checker targets instead of chasing impossible green.
+- Optimize for real engines and GEO, not vanity checker scores.
+- Every finding includes a concrete, implementable fix.
+- Keep output concise: findings + fixes + checklist only.
+
+## Further Reading
+
+- [The Open Graph protocol](https://ogp.me/)
+- [schema.org Article](https://schema.org/Article)
+- [Google Search Central — structured data](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)
+- [llms.txt proposal](https://llmstxt.org/)


### PR DESCRIPTION
Adds an auditing-website-seo-geo skill (meta/OG/Twitter/JSON-LD/GEO with SSG-pitfall + length-conflict guidance) and bumps the accessibility skill to WCAG 2.2 (new criteria added to the quick reference). Versions bumped to 1.1.0 (plugin.json + marketplace.json), marketplace 3.7.0. Content hashes regenerated via the repo script.

Generated with Claude <noreply@anthropic.com>