### PR TITLE
ci: SHA-pin workflow actions + whitelist used actions (fix startup_failure)

### DIFF
--- a/.github/workflows/check-plugin-versions.yaml
+++ b/.github/workflows/check-plugin-versions.yaml
@@ -16,7 +16,7 @@ jobs:
     env:
       BASE_REF: ${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-skill-integrity.yaml
+++ b/.github/workflows/check-skill-integrity.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Verify stable skill content hashes
         run: bash .github/scripts/compute-skill-hashes.sh --check

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+      - uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+      - uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3

--- a/.github/workflows/deploy-mkdocs-ghpages.yaml
+++ b/.github/workflows/deploy-mkdocs-ghpages.yaml
@@ -18,13 +18,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install "mkdocs<2.0" mkdocs-material
       - run: mkdocs build --strict
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site
 
@@ -35,5 +35,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         id: deployment

--- a/.github/workflows/research-monitor.yaml
+++ b/.github/workflows/research-monitor.yaml
@@ -16,16 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout plugins repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Checkout ai-agents-research
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: qte77/ai-agents-research
           path: .research-docs
 
       - name: Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -41,7 +41,7 @@ jobs:
           set -e
 
       - name: Upload findings artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: research-findings
           path: research-findings.md


### PR DESCRIPTION
## Summary

Fixes the repo-wide GitHub Actions `startup_failure` (all workflows failing to start since ~2026-06-19). The repo policy is `allowed_actions: selected` + `sha_pinning_required: true` with empty `patterns_allowed`, so every action must be SHA-pinned **and** GitHub-owned/verified or explicitly whitelisted.

**Two-part fix:**
1. **SHA-pin** all GitHub-owned action refs in the 5 affected workflows (`actions/checkout`, `actions/setup-python`, `actions/upload-pages-artifact`, `actions/deploy-pages`, `actions/upload-artifact`, `github/codeql-action/*`) to full commit SHAs, with `# vX` comments. (`issue-triage` + the `lint-md-links` reusable caller were already pinned.)
2. **Whitelist** (repo settings, via API — not in git): `patterns_allowed` now lists `qte77/.github`, `qte77/gha-issue-triage`, `lycheeverse/lychee-action`, `DavidAnson/markdownlint-cli2-action`.

This PR also retroactively validates #171 (the canon adoption, which merged during the outage with no CI): its new templates + dogfooded README are on `main` and get checked by this PR's `lint / markdown` + `lint / links` runs.

## Type of Change

- [x] `ci`

## Testing

- [x] All `uses:` refs SHA-pinned (verified)
- [x] `patterns_allowed` whitelist applied + verified via API
- [ ] CI now starts (verified by this PR's checks)

🤖 Generated with Claude