### PR TITLE
fix: tighten docs-governance canon derivation (#170 follow-up)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,7 +78,7 @@
       "name": "workspace-setup",
       "source": "./plugins/workspace-setup",
       "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
-      "version": "1.4.0"
+      "version": "1.4.1"
     },
     {
       "name": "workspace-sandbox",
@@ -90,7 +90,7 @@
       "name": "docs-governance",
       "source": "./plugins/docs-governance",
       "description": "Audit and maintain documentation hierarchy and agent governance files",
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     {
       "name": "market-research",
@@ -165,7 +165,7 @@
       "name": "readme-generator",
       "source": "./plugins/readme-generator",
       "description": "Generate and audit README.md files for repos, GitHub accounts, and organizations",
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     {
       "name": "planning",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **readme-generator**: `auditing-readme` + `writing-readme` rewritten to the [qte77 doc-structure canon](https://github.com/qte77/qte77/blob/main/docs/doc-structure.md) — value-first order (Hero → Badges → What → How → Why → Refs → License → tail), badges License → Version → CI (static `blue` / native status, Version linked to `CHANGELOG.md`), `## Refs` not `## Resources`, front-door rule. Plugin 1.1.0 → 1.2.0 (#170)
 - **docs-governance**: `enforcing-doc-hierarchy` discovery now points at the canon's `## Documentation hierarchy` statement (owned by `CONTRIBUTING.md`) (#170)
 - **README**: dogfooded to the canon — What (Plugins) before How (Install), new `## Why`, How fragments collapsed into one section, `Resources` → `Refs`, badges fixed to static `blue` + Version linked to `CHANGELOG.md` (closes #170)
+- **docs-governance**: `templates/CONTRIBUTING.md` now derived verbatim from the upstream `CONTRIBUTING.template.md` canon (provenance header + `@sync:begin` sentinel + `make check_sync` diff-guard), replacing the hand-written copy — closes the remote-drift gap left by #170; `enforcing-doc-hierarchy` opted into `stability: stable` (content-hash CI guard). Plugin 1.5.0 → 1.6.0 (#170 follow-up)
+- **readme-generator**: `auditing-readme` C3 now requires the SPDX id in the License badge label (`License: Apache-2.0`, not bare `license-MIT`); batch Consistency Checks flag an unlinked Version badge; skill opted into `stability: stable`. Plugin 1.2.0 → 1.2.1 (#170 follow-up)
+- **workspace-setup**: `governance/CONTRIBUTING.md` re-synced from the canon-derived template. Plugin 1.4.0 → 1.4.1 (#170 follow-up)
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,17 @@ define DG_README_HEADER
 endef
 export DG_README_HEADER
 
+CANON_CONTRIBUTING_URL := https://raw.githubusercontent.com/qte77/qte77/main/docs/templates/CONTRIBUTING.template.md
+DG_CONTRIBUTING := plugins/docs-governance/templates/CONTRIBUTING.md
+
+define DG_CONTRIBUTING_HEADER
+<!-- DERIVED — do not hand-edit. Source of truth:
+     https://raw.githubusercontent.com/qte77/qte77/main/docs/templates/CONTRIBUTING.template.md
+     Regenerate with 'make sync'; verify with 'make check_sync'. Tracking: qte77/claude-code-plugins#170 -->
+<!-- @sync:begin (content below mirrors the SoT verbatim) -->
+endef
+export DG_CONTRIBUTING_HEADER
+
 sync_rules:  ## Sync rules from .claude/rules/ to plugin copies (all consumers use symlinks; this is a no-op kept for the `sync` target wiring)
 	@true
 
@@ -52,10 +63,12 @@ sync_refs:  ## Sync shared references within plugins (implementing → reviewing
 	cp plugins/rust-dev/skills/implementing-rust/references/rust-best-practices.md plugins/rust-dev/skills/reviewing-rust/references/
 	cp plugins/go-dev/skills/implementing-go/references/go-best-practices.md plugins/go-dev/skills/reviewing-go/references/
 
-sync_canon:  ## Regenerate docs-governance README template from the qte77 doc-structure canon
+sync_canon:  ## Regenerate docs-governance README + CONTRIBUTING templates from the qte77 doc-structure canon
 	printf '%s\n' "$$DG_README_HEADER" > $(DG_README)
 	curl -fsSL $(CANON_README_URL) >> $(DG_README)
-	echo "Synced $(DG_README) from the qte77 canon."
+	printf '%s\n' "$$DG_CONTRIBUTING_HEADER" > $(DG_CONTRIBUTING)
+	curl -fsSL $(CANON_CONTRIBUTING_URL) >> $(DG_CONTRIBUTING)
+	echo "Synced $(DG_README) and $(DG_CONTRIBUTING) from the qte77 canon."
 
 sync_governance:  ## Mirror docs-governance templates into the workspace-setup deploy set
 	cp $(DG_README) plugins/workspace-setup/governance/README.md
@@ -83,6 +96,7 @@ check_sync:  ## Verify all copies are in sync with .claude/ SoT
 	@diff -q plugins/go-dev/skills/implementing-go/references/go-best-practices.md plugins/go-dev/skills/reviewing-go/references/go-best-practices.md
 	@echo "Checking canon + governance sync..."
 	@canon=$$(mktemp); curl -fsSL "$(CANON_README_URL)" -o "$$canon"; awk 'f{print} /@sync:begin/{f=1}' "$(DG_README)" | diff -q - "$$canon" || { echo "ERROR: $(DG_README) drifted from the qte77 canon — run 'make sync'"; rm -f "$$canon"; exit 1; }; rm -f "$$canon"
+	@canon=$$(mktemp); curl -fsSL "$(CANON_CONTRIBUTING_URL)" -o "$$canon"; awk 'f{print} /@sync:begin/{f=1}' "$(DG_CONTRIBUTING)" | diff -q - "$$canon" || { echo "ERROR: $(DG_CONTRIBUTING) drifted from the qte77 canon — run 'make sync'"; rm -f "$$canon"; exit 1; }; rm -f "$$canon"
 	@diff -q "$(DG_README)" plugins/workspace-setup/governance/README.md
 	@diff -q plugins/docs-governance/templates/CONTRIBUTING.md plugins/workspace-setup/governance/CONTRIBUTING.md
 	@echo "All copies in sync."

--- a/plugins/docs-governance/.claude-plugin/plugin.json
+++ b/plugins/docs-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-governance",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Audit and maintain documentation hierarchy and agent governance files",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["docs", "governance", "agents-md", "hierarchy", "audit", "single-source-of-truth"]

--- a/plugins/docs-governance/skills/enforcing-doc-hierarchy/SKILL.md
+++ b/plugins/docs-governance/skills/enforcing-doc-hierarchy/SKILL.md
@@ -5,6 +5,8 @@ compatibility: Designed for Claude Code
 metadata:
   argument-hint: [file-directory-or-full]
   allowed-tools: Read, Grep, Glob, Edit, Bash
+  stability: stable
+  content-hash: sha256:45fb467089ea1670daaa473897dd3b9b108beaf39e4319b851fdce2d678024eb
 ---
 
 # Enforce Documentation Hierarchy

--- a/plugins/docs-governance/templates/CONTRIBUTING.md
+++ b/plugins/docs-governance/templates/CONTRIBUTING.md
@@ -1,61 +1,64 @@
+<!-- DERIVED — do not hand-edit. Source of truth:
+     https://raw.githubusercontent.com/qte77/qte77/main/docs/templates/CONTRIBUTING.template.md
+     Regenerate with 'make sync'; verify with 'make check_sync'. Tracking: qte77/claude-code-plugins#170 -->
+<!-- @sync:begin (content below mirrors the SoT verbatim) -->
+<!--
+  Canonical CONTRIBUTING skeleton for qte77 repos. Copy to your repo root and fill in.
+  Contract & rules: https://github.com/qte77/qte77/blob/main/docs/doc-structure.md
+  Keep the `## Documentation hierarchy` statement (the doc-hierarchy SoT lives here). Keep
+  `## Releasing` only if the repo cuts versioned releases; trim sections that don't apply.
+-->
+
 # Contributing
 
-Technical workflows, coding standards, and command references for this project.
-For behavioral rules and decision frameworks, see [AGENTS.md](AGENTS.md).
+For agent behavioural rules see [AGENTS.md](AGENTS.md).
 
 ## Documentation hierarchy
 
-One audience per file; no duplication. Derived from the
-[qte77 doc-structure canon](https://github.com/qte77/qte77/blob/main/docs/doc-structure.md).
+One audience per file — reference, don't duplicate (estate contract: [doc-structure.md](https://github.com/qte77/qte77/blob/main/docs/doc-structure.md)):
 
 | File | Audience | Owns |
 | --- | --- | --- |
-| `README.md` | users / evaluators | the project contract (value-first front door) |
-| `CONTRIBUTING.md` | contributors | commands, conventions, this hierarchy statement |
-| `AGENTS.md` | AI agents | behavioural rules, decision framework |
-| `CLAUDE.md` | Claude Code loader | a one-line `@AGENTS.md` pointer — never a copy |
+| [README.md](README.md) | users / evaluators | what this is, why, how — the front door |
+| CONTRIBUTING.md (this file) | contributors | workflow, commands, conventions, releasing |
+| [AGENTS.md](AGENTS.md) | AI agents | behavioural rules, decision frameworks (`CLAUDE.md` loads the same) |
+| [CHANGELOG.md](CHANGELOG.md) | everyone | notable changes by version |
 
-## Development Setup
+## Commands
 
-<!-- Project-specific setup commands. Common patterns:
-- `make setup` — install dev dependencies
-- `make setup_claude_code` — install Claude Code CLI
-- Document any required env vars or external services
--->
+```bash
+# the repo's build / test / lint entry points, e.g.
+make help
+markdownlint $(git ls-files '*.md')
+lychee --offline $(git ls-files '*.md')
+```
 
-## Testing
+## Conventional Commits
 
-<!-- Test framework and commands. Examples:
-- `make test_all` — run full test suite
-- `make test_single FILE=<path>` — run a specific test
-- Coverage thresholds and how to view reports
--->
+`feat`, `fix`, `docs`, `chore`, `refactor`. Optional scope: `feat(SCOPE): ...`. PR titles match.
 
-## Code Style
+## Branches
 
-<!-- Lint and format commands. Examples:
-- `make ruff` (Python) / `make fmt` (Go) / `npm run lint` (TS)
-- Static type checking command
-- Style guide reference (PEP 8, Google style, etc.)
--->
+- `feat/TOPIC`, `fix/TOPIC`, `docs/TOPIC`, `chore/TOPIC`
+- Squash-merge is default. Force-push only with `--force-with-lease`, never to `main`.
 
-## Pre-commit Checklist
+## CHANGELOG
 
-1. <!-- format/lint command -->
-2. <!-- type-check command -->
-3. <!-- test command -->
-4. Update documentation if patterns changed
-5. Update CHANGELOG.md for non-trivial changes
+Add an entry under `[Unreleased]` for any consumer-visible change; lead with the file path. (Or use `changelog.d/` fragments via `make changelog_new` if the repo uses scriv.)
 
-## Pull Requests
+## Releasing
 
-- **Title**: Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`)
-- **Body**: detailed summary of purpose + test plan checklist
-- Link related issues by number
-- Provide screenshots for UI changes
+<!-- For repos that cut versioned releases. Delete this section for profile / docs / action-only repos. -->
 
-## Documentation
+Semi-automatic: a **human-authored** bump PR (so the merge is a real-user event → no bot `action_required` gotcha), automatic tag, one-command publish. SemVer; the version source of truth lives in the package manifest, mirrored in the README version badge (`-blue`).
 
-- Apply [markdownlint rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)
-- Use ISO 8601 timestamps (`YYYY-MM-DDTHH:MM:SSZ`)
-- Update AGENTS.md when introducing new agent patterns
+1. Release PR: bump with the repo's tool (`uv run bump-my-version bump PART`, `npm version PART --no-git-tag-version`, …), update the README badge, and roll `## [Unreleased]` → `## [X.Y.Z] - DATE` in `CHANGELOG.md` (or `scriv collect`).
+2. Merge → `tag-release` tags `vX.Y.Z` on the version change.
+3. Optionally run `publish-release` for a GitHub Release from the matching `CHANGELOG.md` block. Tag-only is fine.
+
+## Pre-merge
+
+1. `markdownlint` clean
+2. `lychee --offline` clean
+3. CHANGELOG `[Unreleased]` updated
+4. Conventional Commits title

--- a/plugins/readme-generator/.claude-plugin/plugin.json
+++ b/plugins/readme-generator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-generator",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Generate and audit README.md files for repos, GitHub accounts, and organizations",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["readme", "profile", "organization", "github", "documentation", "audit"]

--- a/plugins/readme-generator/skills/auditing-readme/SKILL.md
+++ b/plugins/readme-generator/skills/auditing-readme/SKILL.md
@@ -5,6 +5,8 @@ compatibility: Designed for Claude Code
 metadata:
   argument-hint: <scope> [target-or-glob]
   allowed-tools: Read, Grep, Glob, Bash, WebFetch, Agent
+  stability: stable
+  content-hash: sha256:5862812c4909f9f641e1c0b1f63f1d2d722677f68ecafa2304dc8f2e18bbd1ce
 ---
 
 # Audit README
@@ -64,7 +66,7 @@ Derives from the [canon contract](https://github.com/qte77/qte77/blob/main/docs/
 |---|-------|-------|----------------|
 | C1 | Hero | required | H1 name + one-line tagline (what · who-for · positioning); optional wordmark is theme-aware + self-hosted |
 | C2 | Section order | required | Value-first: Hero → Badges → What → How → Why → Refs → License → \<tail\> |
-| C3 | Badges | required | Order License → Version → CI; License & Version shields.io static `blue`; Version linked to `CHANGELOG.md`; status badges native color; left-aligned, no `<p align="center">` |
+| C3 | Badges | required | Order License → Version → CI; License & Version shields.io static `blue`; License label carries the SPDX id (e.g. `License: Apache-2.0`, not bare `license-MIT`); Version linked to `CHANGELOG.md`; status badges native color; left-aligned, no `<p align="center">` |
 | C4 | What | required | `## What` present, ≤ ~7 reader-value bullets |
 | C5 | How | required | `## How` minimal run example + link out to `docs/` |
 | C6 | Why | required | `## Why` 2–4 lines (incumbent → gap → differentiation) |
@@ -129,6 +131,7 @@ Summary: X/Y required pass, Z/W recommended pass.
 
 - Section order matches the canon (Hero → Badges → What → How → Why → Refs → License → tail)?
 - Badge order/colors consistent (License → Version → CI; static `blue` / native status)?
+- Version badge linked to `CHANGELOG.md` (flag a bare `![Version](…)`)?
 - Canon section names used (`## What` / `## How` / `## Why` / `## Refs`, not `## Resources`)?
 - License format consistent (`LICENSE` not `LICENSE.md`)?
 

--- a/plugins/workspace-setup/.claude-plugin/plugin.json
+++ b/plugins/workspace-setup/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-setup",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "governance", "setup", "read-once"]

--- a/plugins/workspace-setup/governance/CONTRIBUTING.md
+++ b/plugins/workspace-setup/governance/CONTRIBUTING.md
@@ -1,61 +1,64 @@
+<!-- DERIVED — do not hand-edit. Source of truth:
+     https://raw.githubusercontent.com/qte77/qte77/main/docs/templates/CONTRIBUTING.template.md
+     Regenerate with 'make sync'; verify with 'make check_sync'. Tracking: qte77/claude-code-plugins#170 -->
+<!-- @sync:begin (content below mirrors the SoT verbatim) -->
+<!--
+  Canonical CONTRIBUTING skeleton for qte77 repos. Copy to your repo root and fill in.
+  Contract & rules: https://github.com/qte77/qte77/blob/main/docs/doc-structure.md
+  Keep the `## Documentation hierarchy` statement (the doc-hierarchy SoT lives here). Keep
+  `## Releasing` only if the repo cuts versioned releases; trim sections that don't apply.
+-->
+
 # Contributing
 
-Technical workflows, coding standards, and command references for this project.
-For behavioral rules and decision frameworks, see [AGENTS.md](AGENTS.md).
+For agent behavioural rules see [AGENTS.md](AGENTS.md).
 
 ## Documentation hierarchy
 
-One audience per file; no duplication. Derived from the
-[qte77 doc-structure canon](https://github.com/qte77/qte77/blob/main/docs/doc-structure.md).
+One audience per file — reference, don't duplicate (estate contract: [doc-structure.md](https://github.com/qte77/qte77/blob/main/docs/doc-structure.md)):
 
 | File | Audience | Owns |
 | --- | --- | --- |
-| `README.md` | users / evaluators | the project contract (value-first front door) |
-| `CONTRIBUTING.md` | contributors | commands, conventions, this hierarchy statement |
-| `AGENTS.md` | AI agents | behavioural rules, decision framework |
-| `CLAUDE.md` | Claude Code loader | a one-line `@AGENTS.md` pointer — never a copy |
+| [README.md](README.md) | users / evaluators | what this is, why, how — the front door |
+| CONTRIBUTING.md (this file) | contributors | workflow, commands, conventions, releasing |
+| [AGENTS.md](AGENTS.md) | AI agents | behavioural rules, decision frameworks (`CLAUDE.md` loads the same) |
+| [CHANGELOG.md](CHANGELOG.md) | everyone | notable changes by version |
 
-## Development Setup
+## Commands
 
-<!-- Project-specific setup commands. Common patterns:
-- `make setup` — install dev dependencies
-- `make setup_claude_code` — install Claude Code CLI
-- Document any required env vars or external services
--->
+```bash
+# the repo's build / test / lint entry points, e.g.
+make help
+markdownlint $(git ls-files '*.md')
+lychee --offline $(git ls-files '*.md')
+```
 
-## Testing
+## Conventional Commits
 
-<!-- Test framework and commands. Examples:
-- `make test_all` — run full test suite
-- `make test_single FILE=<path>` — run a specific test
-- Coverage thresholds and how to view reports
--->
+`feat`, `fix`, `docs`, `chore`, `refactor`. Optional scope: `feat(SCOPE): ...`. PR titles match.
 
-## Code Style
+## Branches
 
-<!-- Lint and format commands. Examples:
-- `make ruff` (Python) / `make fmt` (Go) / `npm run lint` (TS)
-- Static type checking command
-- Style guide reference (PEP 8, Google style, etc.)
--->
+- `feat/TOPIC`, `fix/TOPIC`, `docs/TOPIC`, `chore/TOPIC`
+- Squash-merge is default. Force-push only with `--force-with-lease`, never to `main`.
 
-## Pre-commit Checklist
+## CHANGELOG
 
-1. <!-- format/lint command -->
-2. <!-- type-check command -->
-3. <!-- test command -->
-4. Update documentation if patterns changed
-5. Update CHANGELOG.md for non-trivial changes
+Add an entry under `[Unreleased]` for any consumer-visible change; lead with the file path. (Or use `changelog.d/` fragments via `make changelog_new` if the repo uses scriv.)
 
-## Pull Requests
+## Releasing
 
-- **Title**: Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`)
-- **Body**: detailed summary of purpose + test plan checklist
-- Link related issues by number
-- Provide screenshots for UI changes
+<!-- For repos that cut versioned releases. Delete this section for profile / docs / action-only repos. -->
 
-## Documentation
+Semi-automatic: a **human-authored** bump PR (so the merge is a real-user event → no bot `action_required` gotcha), automatic tag, one-command publish. SemVer; the version source of truth lives in the package manifest, mirrored in the README version badge (`-blue`).
 
-- Apply [markdownlint rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)
-- Use ISO 8601 timestamps (`YYYY-MM-DDTHH:MM:SSZ`)
-- Update AGENTS.md when introducing new agent patterns
+1. Release PR: bump with the repo's tool (`uv run bump-my-version bump PART`, `npm version PART --no-git-tag-version`, …), update the README badge, and roll `## [Unreleased]` → `## [X.Y.Z] - DATE` in `CHANGELOG.md` (or `scriv collect`).
+2. Merge → `tag-release` tags `vX.Y.Z` on the version change.
+3. Optionally run `publish-release` for a GitHub Release from the matching `CHANGELOG.md` block. Tag-only is fine.
+
+## Pre-merge
+
+1. `markdownlint` clean
+2. `lychee --offline` clean
+3. CHANGELOG `[Unreleased]` updated
+4. Conventional Commits title


### PR DESCRIPTION
## Summary

Four review follow-ups to #170, tightening the canon derivation.

1. **Anchor `CONTRIBUTING.md` to its new upstream SOT.** qte77/qte77 added `docs/templates/CONTRIBUTING.template.md`; the hand-written copy is now a **verbatim derived copy** (provenance header + `@sync:begin` sentinel), regenerated by `make sync` and drift-guarded by `make check_sync` against the raw SOT — same treatment as `README.md`. Closes the un-anchored-copy gap. Re-synced into `workspace-setup/governance/`.
2. **auditing-readme C3 — SPDX-id-in-label.** The License badge must carry the SPDX id (`License: Apache-2.0`), not a bare `license-MIT-blue`, per the canon Badges section.
3. **auditing-readme batch Consistency Checks — unlinked Version badge.** The cross-repo sweep now flags a bare `![Version](…)` (the per-repo C3 already required the CHANGELOG link).
4. **Stability opt-in.** `auditing-readme` + `enforcing-doc-hierarchy` now `stability: stable` with regenerated `content-hash`, so the skill-hash CI guards them against silent regression.

The SOT badge-order ASCII typo (P1) was already fixed upstream; the plugin derived from the Badges section, so no change needed there.

## Type of Change

- [x] `fix` (derivation tightening) + `ci` (CONTRIBUTING sync/guard)

## Testing

- [x] `make validate` passes
- [x] `make check_sync` passes — incl. new CONTRIBUTING canon diff-guard + governance copy
- [x] `compute-skill-hashes.sh --check` passes (two newly-stable skills hashed)

## Version bumps

- docs-governance 1.5.0 → 1.6.0 · readme-generator 1.2.0 → 1.2.1 · workspace-setup 1.4.0 → 1.4.1

🤖 Generated with Claude