### PR TITLE
chore: repo hygiene + canon completion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "qte77-claude-code-utils",
+  "name": "qte77-claude-code-plugins",
   "owner": {
     "name": "qte77"
   },
@@ -114,7 +114,7 @@
       "name": "gha-dev",
       "source": "./plugins/gha-dev",
       "description": "Skills and rules for creating GitHub Actions for the Marketplace",
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     {
       "name": "tdd-core",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/canon-drift.yaml
+++ b/.github/workflows/canon-drift.yaml
@@ -1,0 +1,62 @@
+name: Canon Drift Check
+
+# Weekly guard that the docs-governance derived templates still match the qte77
+# doc-structure canon (SoT). The make check_sync diff-guard runs only locally;
+# this gives it CI teeth. Opens a single sticky issue on drift.
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Mondays 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Diff derived templates against the qte77 canon
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Compare derived templates against the canon SoT
+        id: drift
+        shell: bash
+        run: |
+          set -uo pipefail
+          base="https://raw.githubusercontent.com/qte77/qte77/main/docs/templates"
+          status=0
+          : > drift.md
+          compare() {
+            src="$1"; dst="$2"
+            canon="$(mktemp)"
+            if ! curl -fsSL "$base/$src" -o "$canon"; then
+              printf '### Could not fetch %s from the canon\n\n' "$src" >> drift.md
+              status=1; return
+            fi
+            if ! awk 'f{print} /@sync:begin/{f=1}' "$dst" | diff -u - "$canon" > "$canon.diff" 2>&1; then
+              printf '### %s drifted from %s\n\n```diff\n' "$dst" "$src" >> drift.md
+              cat "$canon.diff" >> drift.md
+              printf '```\n\n' >> drift.md
+              status=1
+            fi
+          }
+          compare README.template.md plugins/docs-governance/templates/README.md
+          compare CONTRIBUTING.template.md plugins/docs-governance/templates/CONTRIBUTING.md
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Open issue on drift
+        if: steps.drift.outputs.status != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$(gh issue list --state open --search 'Canon drift in:title' --json number --jq 'length')" != "0" ]; then
+            echo "An open canon-drift issue already exists; skipping."
+            exit 0
+          fi
+          gh issue create \
+            --title "Canon drift: docs-governance templates differ from the qte77 canon" \
+            --body-file drift.md

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -10,7 +10,3 @@
 https://www\.fcc\.gov/engineering-technology/laboratory-division/general/equipment-authorization
 https://insta\.rs
 https://www\.awwwards\.com
-
-# Root AGENTS.md forward-references a repo-root CONTRIBUTING.md (governance
-# convention) that resolves in consumer repos, not in this marketplace source.
-CONTRIBUTING\.md$

--- a/AGENT_REQUESTS.md
+++ b/AGENT_REQUESTS.md
@@ -15,18 +15,6 @@ description: Escalation protocol and active requests requiring human decision
 
 ## Active Requests
 
-- [ ] [LOW] Restore marketplace.json `name` field to `qte77-claude-code-plugins`
-
-  **Context:** PR #120 (`5f6a203`, "chore: rename repo references to claude-code-plugins") renamed the marketplace from `qte77-claude-code-utils` to `qte77-claude-code-plugins`. PR #122 (`9c50b2a`) silently reverted the marketplace.json side as part of a rebase artifact (same root cause as the version drift fixed in #134).
-
-  **Problem:** marketplace.json line 2 still reads `"name": "qte77-claude-code-utils"`. Repo and plugin paths use `claude-code-plugins`; only the marketplace identifier is stale. Possible breakage: existing users who added the marketplace by name may have a stale identifier; new users get the correct one. No errors observed in practice.
-
-  **Files:** `.claude-plugin/marketplace.json` (line 2)
-
-  **Alternatives:** (a) Restore to `qte77-claude-code-plugins` (intent of #120). (b) Keep `qte77-claude-code-utils` and revert #120's intent — but the README, repo, plugin paths, and PR titles all moved on. (a) is the consistent choice.
-
-  **Impact:** Cosmetic. Low risk — one-line edit. Bundle into the next marketplace-touching PR or do standalone.
-
 - [ ] [LOW] Fix `make sync` broken target for `compacting-context` skill
 
   **Context:** `Makefile` line 40 copies `.claude/scripts/read-once/...` and `context-management.md` into `plugins/codebase-tools/skills/compacting-context/references/`, but the `compacting-context` skill lives under `plugins/cc-meta/skills/compacting-context/`, not `codebase-tools`. `make sync` fails with `cp: cannot create regular file ... No such file or directory` after partially copying earlier targets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **docs-governance**: `templates/README.md` — value-first README skeleton derived verbatim from the [qte77 doc-structure canon](https://github.com/qte77/qte77/blob/main/docs/doc-structure.md) with a `make check_sync` diff-guard; `templates/CONTRIBUTING.md` gains a `## Documentation hierarchy` statement. Plugin 1.4.0 → 1.5.0 (#170)
 - **workspace-setup**: SessionStart deploy set now includes canon-derived `README.md` + `CONTRIBUTING.md` skeletons. Plugin 1.3.12 → 1.4.0 (#170)
 - **Makefile / lychee**: `sync_canon` + `sync_governance` targets and `check_sync` diff-guards keep the canon-derived copies in sync with qte77/qte77; `lychee.toml` (mirrors shared `accept`) excludes skeleton/template files from link-checking (#170)
+- **CI / canon-drift**: `.github/workflows/canon-drift.yaml` — weekly diff of the docs-governance derived templates against the qte77 canon, opening a sticky issue on drift (gives the local `make check_sync` guard CI teeth) (#170 follow-up)
+- **CI / dependabot**: `.github/dependabot.yml` — weekly grouped SHA-bump PRs for GitHub Actions, keeping the SHA-pinned actions from #172 current
+- **CONTRIBUTING.md** (repo root): canon-structured contributor guide that owns the `## Documentation hierarchy` statement; removes the `.lycheeignore` CONTRIBUTING.md forward-ref workaround
 
 #### New agents (#38-#112)
 
@@ -144,6 +147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixes (#38-#112)
 
 - **marketplace**: Use github source for `cc-voice` plugin (installable from external repo, not local path) (#80)
+- **marketplace**: `name` corrected `qte77-claude-code-utils` → `qte77-claude-code-plugins` to match every README / `gha-dev` install instruction; `gha-dev` `companion-plugins.md` examples updated. gha-dev 1.2.0 → 1.2.1
 - **python-dev**: `testing-python/SKILL.md` content-hash drift from #94 merge — CI `verify-skill-hashes` would have blocked next PR; regenerated via `.github/scripts/compute-skill-hashes.sh --update` as part of #107
 - **broken md links** (`lint / links` green): repaired cross-skill references in `mas-design` (`mas-security.md` ↔ `mas-design-principles.md` now use `../../<skill>/references/` paths); repointed `python-dev` `python-best-practices.md` testing links to `testing-python/references/` and dropped the BDD link (skill is TDD-only); removed the rotted EU Blue Guide URL from `embedded-dev` `compliance-standards.md`. Added `.lycheeignore` for the FCC page (HTTP/2 crawler error, valid for humans) and governance/template files that forward-reference consumer-repo `CONTRIBUTING.md`/`README.md`. Plugin versions: mas-design 1.1.1 → 1.1.2, python-dev 2.1.3 → 2.1.4, embedded-dev 1.2.2 → 1.2.3 (#163)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+Technical workflow, commands, and conventions for this marketplace. For AI-agent
+behavioural rules and decision frameworks, see [AGENTS.md](AGENTS.md).
+
+## Documentation hierarchy
+
+One audience per file; reference, don't duplicate. Derived from the
+[qte77 doc-structure canon](https://github.com/qte77/qte77/blob/main/docs/doc-structure.md).
+
+| File | Audience | Owns |
+| --- | --- | --- |
+| [README.md](README.md) | users / evaluators | what this is, why, how — the front door |
+| CONTRIBUTING.md (this file) | contributors | commands, conventions, this hierarchy statement |
+| [AGENTS.md](AGENTS.md) | AI agents | behavioural rules, decision frameworks (`CLAUDE.md` loads the same) |
+| [CHANGELOG.md](CHANGELOG.md) | everyone | notable changes |
+
+## Commands
+
+```bash
+make help         # list all recipes
+make validate     # plugin structure + JSON syntax
+make sync         # sync shared refs + the qte77 doc-structure canon into plugin dirs
+make check_sync   # verify all copies match their source (incl. the canon diff-guard)
+make lint_md      # markdownlint (--fix)
+make test_install # marketplace add + install + cleanup
+```
+
+## Conventional Commits
+
+Per [`.gitmessage`](.gitmessage): `feat`, `fix`, `docs`, `chore`, `ci`, `refactor`,
+`style`, `revert`, `test`; optional scope `type(scope):`. Split commits by type; PR titles match.
+
+## Branches & PRs
+
+- Branch names: `feat/TOPIC`, `fix/TOPIC`, `docs/TOPIC`, `chore/TOPIC`, `ci/TOPIC`.
+- Never push directly to `main`; land via PR. Squash-merge is default; force-push only with `--force-with-lease`.
+- Fill in the [pull request template](.github/pull_request_template.md).
+
+## Plugin versioning
+
+Any change under `plugins/<name>/` MUST bump that plugin's `version` in **both**
+`plugins/<name>/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (they must
+match) — see [`.claude/rules/plugin-versioning.md`](.claude/rules/plugin-versioning.md). Stable
+skills (`stability: stable`) also need `bash .github/scripts/compute-skill-hashes.sh --update`.
+
+## CHANGELOG
+
+Add an entry under `## [Unreleased]` in [CHANGELOG.md](CHANGELOG.md) for any consumer-visible
+change ([Keep a Changelog](https://keepachangelog.com/) format).
+
+## Pre-merge
+
+1. `make validate` + `make check_sync` clean
+2. markdownlint + lychee clean (the CI `lint` workflow)
+3. CHANGELOG `[Unreleased]` updated
+4. Conventional Commits PR title

--- a/plugins/gha-dev/.claude-plugin/plugin.json
+++ b/plugins/gha-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-dev",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Skills and rules for creating GitHub Actions for the Marketplace",
   "author": {
     "name": "Claude Code Utils Contributors"

--- a/plugins/gha-dev/skills/creating-gha/references/companion-plugins.md
+++ b/plugins/gha-dev/skills/creating-gha/references/companion-plugins.md
@@ -1,7 +1,7 @@
 # Companion Plugins
 
-Plugins from `qte77-claude-code-utils` that complement GHA development.
-Install with `claude plugin install <name>@qte77-claude-code-utils`.
+Plugins from `qte77-claude-code-plugins` that complement GHA development.
+Install with `claude plugin install <name>@qte77-claude-code-plugins`.
 
 ## By workflow phase
 
@@ -41,19 +41,19 @@ Install with `claude plugin install <name>@qte77-claude-code-utils`.
 **Shell-based action** (minimal):
 
 ```bash
-claude plugin install tdd-core@qte77-claude-code-utils
-claude plugin install commit-helper@qte77-claude-code-utils
-claude plugin install simplify@qte77-claude-code-utils
+claude plugin install tdd-core@qte77-claude-code-plugins
+claude plugin install commit-helper@qte77-claude-code-plugins
+claude plugin install simplify@qte77-claude-code-plugins
 ```
 
 **Python-based action** (full):
 
 ```bash
-claude plugin install python-dev@qte77-claude-code-utils
-claude plugin install tdd-core@qte77-claude-code-utils
-claude plugin install commit-helper@qte77-claude-code-utils
-claude plugin install simplify@qte77-claude-code-utils
-claude plugin install security-audit@qte77-claude-code-utils
+claude plugin install python-dev@qte77-claude-code-plugins
+claude plugin install tdd-core@qte77-claude-code-plugins
+claude plugin install commit-helper@qte77-claude-code-plugins
+claude plugin install simplify@qte77-claude-code-plugins
+claude plugin install security-audit@qte77-claude-code-plugins
 ```
 
 ## Global rules


### PR DESCRIPTION
## Summary

Four follow-ups from the post-task review.

- **fix — marketplace name (#4).** `marketplace.json` `name` was `qte77-claude-code-utils` while every README/install command uses `qte77-claude-code-plugins`. Aligned the manifest; updated `gha-dev` `companion-plugins.md` install examples (gha-dev 1.2.0 → 1.2.1). Resolves the open `AGENT_REQUESTS` item.
- **ci — canon-drift guard (#1).** New `canon-drift.yaml` (weekly + dispatch) diffs the docs-governance derived templates against the qte77 canon raw SoT and opens a sticky issue on drift — CI teeth for the local `make check_sync` guard.
- **ci — Dependabot (#2).** `.github/dependabot.yml` weekly grouped SHA-bump PRs for GitHub Actions, keeping the #172 pins current.
- **docs — root `CONTRIBUTING.md` (#3).** Canon-structured; owns the `## Documentation hierarchy` statement; closes the gap where root `AGENTS.md` linked to a missing file. Lets us drop the `.lycheeignore` CONTRIBUTING.md forward-ref workaround.

Stability sweep (#8) is tracked separately as an issue. Per-plugin README canon pass was intentionally not done — component READMEs are not canon-governed repo front-doors.

## Type of Change

- [x] `fix` + `ci` + `docs` (split by type in commits)

## Testing

- [x] `make validate` + `make check_sync` + `compute-skill-hashes.sh --check` pass
- [ ] CI (`lint`, CodeQL, version-bumps) verified on this PR

## Version bumps

- gha-dev 1.2.0 → 1.2.1

🤖 Generated with Claude