### PR TITLE
feat(web-recon): add web-recon assessment skill/plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -172,6 +172,12 @@
       "source": "./plugins/planning",
       "description": "Feature and refactor planning agents \u2014 detailed implementation plans with phased steps, dependencies, risks, and success criteria",
       "version": "1.0.1"
+    },
+    {
+      "name": "web-recon",
+      "source": "./plugins/web-recon",
+      "description": "Authorized web/API reconnaissance & attack-surface assessment \u2014 endpoint enumeration, auth-posture matrix, BOLA/BFLA, gate classification; drives the web-recon-kit harness",
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/web-recon/.claude-plugin/plugin.json
+++ b/plugins/web-recon/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "web-recon",
+  "version": "0.1.0",
+  "description": "Authorized web/API reconnaissance & attack-surface assessment — endpoint enumeration, auth-posture matrix, BOLA/BFLA, gate classification; drives the web-recon-kit harness",
+  "author": {
+    "name": "qte77"
+  }
+}

--- a/plugins/web-recon/README.md
+++ b/plugins/web-recon/README.md
@@ -1,0 +1,22 @@
+# web-recon
+
+Authorized **web/API reconnaissance & attack-surface assessment** for Claude Code. Drives the
+[web-recon-kit][kit] harness (config-driven via `scope.toml`) through recon → API testing → authz
+(BOLA/BFLA) → verified report.
+
+## Skill
+
+- **web-recon** — end-to-end authorized recon/assessment workflow. Authorization-gated; the
+  underlying runners are read-only (GET/OPTIONS), throttled, and never trigger cron/mutation.
+
+## Requires
+
+- A [web-recon-kit][kit] checkout (the Python engine).
+- A [polyfetch-scrape][poly] checkout for the browser tier (consumed via the
+  `uv run --directory` env-borrow contract).
+
+See the web-recon-kit README for setup and the per-target `scope.toml` schema. Abbreviations
+(BOLA, BFLA, IDOR, RBAC, …) are expanded in the skill and in the harness `docs/glossary.md`.
+
+[kit]: https://github.com/qte77/web-recon-kit
+[poly]: https://github.com/qte77/polyfetch-scrape

--- a/plugins/web-recon/skills/web-recon/SKILL.md
+++ b/plugins/web-recon/skills/web-recon/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: web-recon
+description: Authorized web/API reconnaissance & attack-surface assessment. Use when asked to recon, enumerate, map the attack surface of, or security-assess a site/API the user owns or is authorized to test — route/endpoint enumeration, auth-posture mapping, cross-tenant BOLA/BFLA, cron & secret checks. Drives the web-recon-kit harness (config-driven via scope.toml). Requires explicit authorization; refuses unauthorized targets.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Write, Edit, Bash, WebFetch
+  argument-hint: [target-base-url]
+  stability: experimental
+---
+
+# Web / API Reconnaissance & Assessment
+
+**Target**: $ARGUMENTS
+
+Drive the [web-recon-kit][kit] harness to enumerate and assess a web/API target. Every
+target-specific detail lives in `scope.toml`; the runners are read-only (GET/OPTIONS), throttled,
+and never trigger cron/mutation endpoints.
+
+[kit]: https://github.com/qte77/web-recon-kit
+
+## 0. Authorization gate (MANDATORY)
+
+Before ANY request to the target, confirm the user **owns or is explicitly authorized** to test
+it — their own workspace/account, a written pentest scope, an in-scope bug-bounty program, or a
+CTF. If authorization is unclear, STOP and ask. Refuse targets the user does not control. Never
+run against a third party "just to see."
+
+## 1. Set up the target profile
+
+- Ensure a `web-recon-kit` checkout is available (git submodule / sibling clone), plus a
+  `polyfetch-scrape` checkout for the browser tier.
+- `cp scope.example.toml scope.toml`, then fill in:
+  - `base_url`; `[identities.*].env` (env-var NAMES holding the API keys — keys live in `.env`,
+    never in `scope.toml`);
+  - `[recon].routes`, `[authmatrix].public_ok`, `[bfla].admin_prefixes`, `[[bola.collectors]]`.
+
+## 2. Passive enumeration (no auth)
+
+- `make inventory POLY=<polyfetch>` — mine `/api/*` endpoints from the JS bundles.
+- `make recon POLY=<polyfetch>` — render each route, classify its gate (public / client-side /
+  server-middleware), capture screenshots.
+- Record anything reachable without authentication.
+
+## 3. API testing (owner identity)
+
+- `make authmatrix` — every endpoint × every configured identity, GET-probed → auth-posture
+  matrix; flag unauthenticated 200s on non-public paths (then body-check them — an empty/generic
+  200 is not a leak).
+- `make cron` — confirm cron endpoints reject unauthenticated requests.
+
+## 4. Authorization / tenant isolation
+
+- `make bola` — cross-tenant **IDOR** (Insecure Direct Object Reference), a.k.a. **BOLA** (Broken
+  Object-Level Authorization): collect owner resource IDs, replay them as a second tenant
+  (`tenant_b`). A 200 == cross-tenant leak. Needs a 2nd tenant identity.
+- `make bfla` — **BFLA** (Broken Function-Level Authorization): probe admin / **RBAC** (Role-Based
+  Access Control) endpoints as a low-role member; any success is privilege escalation.
+
+Abbreviations are expanded on first use here; the web-recon-kit repo carries a fuller
+`docs/glossary.md`.
+
+## 5. Aggregate + verify
+
+- `make report` → `results/report.md`.
+- Run the harness's `verify_findings` workflow (agentic, adversarial) over candidate findings
+  BEFORE writing anything up — independent panels judge each; a 200 may be a legitimately-public
+  resource, `403 ≠ leak`, and status alone rarely proves a cross-tenant read.
+
+## 6. Report
+
+Produce a **provenance-tagged** report: which tool established each fact (curl / WebFetch /
+polyfetch / harness), severity, and a repro. Separate **confirmed** findings from **candidates**.
+Recommend remediation.
+
+## Safety rails
+
+- Read-only by default; mutating verbs are never emitted (cron/BOLA/BFLA probes are GETs).
+  Any `--danger-post`-style path requires an explicit, disposable environment.
+- Throttled per-host (`rate.per_host_delay_ms`) — never DoS; no mass-fuzzing without authorization.
+- `scope.toml`, `results/`, and the generated inventory are git-ignored (they hold target data).
+- BOLA and schemathesis need extra inputs (a 2nd identity / an OpenAPI spec); the runners skip
+  cleanly when those are absent — report the gap rather than silently covering less.


### PR DESCRIPTION
## Why

Makes **authorized web/API reconnaissance & attack-surface assessment** a first-class,
`/`-invokable capability across projects, instead of ad-hoc per-engagement scripting. It pairs
the marketplace with the standalone [web-recon-kit][kit] engine (a target-agnostic harness
extracted from a real engagement) and complements the existing [security-audit][sec] plugin
(which audits *your own* code) by covering *black/grey-box* recon of a running target.

## What

A new `plugins/web-recon/` plugin:

- `.claude-plugin/plugin.json` — manifest (`web-recon`, v0.1.0)
- `skills/web-recon/SKILL.md` — the workflow skill (`stability: experimental`)
- `README.md`

and one line in `.claude-plugin/marketplace.json` registering it.

The **web-recon** skill drives [web-recon-kit][kit] end-to-end: authorization gate → passive
enumeration (JS-bundle mining, gate classification, screenshots) → API auth-posture matrix +
cron checks → cross-tenant **BOLA** / **BFLA** → aggregate + adversarial verify →
provenance-tagged report.

## How

- **Authorization-gated** — the skill refuses targets the user doesn't own / isn't authorized to
  test, before any request. Runners are read-only (GET/OPTIONS), throttled, and never trigger
  cron/mutation endpoints.
- **Config-driven / target-agnostic** — all target specifics live in the kit's `scope.toml`
  (git-ignored); the skill itself names no target.
- **Engine reuse** — the kit consumes [polyfetch-scrape][poly] via the `uv run --directory`
  env-borrow contract for the browser tier.
- Abbreviations (BOLA, BFLA, IDOR, RBAC, …) are expanded on first use; a fuller glossary lives in
  the kit's `docs/glossary.md`.

## Notes for review

- Please merge **without squash** (per request) to preserve the commit.
- `marketplace.json` `metadata.version` was **not** bumped — apply per your release process.
- Mirrors the structure/format of the `security-audit` and `codebase-tools` plugins.

[kit]: https://github.com/qte77/web-recon-kit
[poly]: https://github.com/qte77/polyfetch-scrape
[sec]: ./plugins/security-audit
