### PR TITLE
[PARKED] feat: add unattended-run kit to workspace-setup deployed set (pre-stages qte77 arc-003)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,8 +77,8 @@
     {
       "name": "workspace-setup",
       "source": "./plugins/workspace-setup",
-      "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
-      "version": "1.4.1"
+      "description": "Deploys workspace rules, statusline, governance files, base settings, unattended-run templates, and read-once deduplication hook",
+      "version": "1.5.0"
     },
     {
       "name": "workspace-sandbox",

--- a/.claude/rules/unattended-execution.md
+++ b/.claude/rules/unattended-execution.md
@@ -1,0 +1,78 @@
+# Unattended Execution
+
+Always-loaded constraints for **long-running, e2e hands-off unattended sessions** with minimal
+supervision. Constraints only; the contract, rationale, and mechanism spec live in
+[`docs/unattended-execution.md`](https://github.com/qte77/qte77/blob/main/docs/unattended-execution.md). Pairs with
+[`context-management.md`](context-management.md) (compaction) and
+[`compound-learning.md`](compound-learning.md) (learnings promotion).
+
+## Plan + handoff (per arc `NNN`)
+
+- Every arc is a paired `docs/plans/NNN-slug.md` + `docs/handoffs/NNN-slug.md` (same number, kebab
+  slug; match the repo's existing digit width). Findings reuse the number with a `-findings` suffix.
+- The **plan MUST carry a `file:line` source map** ("touch without re-mapping") so the next session
+  does not re-explore. The **handoff onboards** the next session: state, ordered next steps, the loop,
+  owner-gates, commands, gotchas. Read the handoff first, the plan second.
+- Keep plan + handoff + `MEMORY.md` in sync at every milestone. **Close an arc by migrating the entire
+  remainder to the next `NNN`** — never strand work in a closed arc.
+- **Plans, handoffs, findings, memory, and session summaries are EPHEMERAL working state, not permanent
+  docs.** Evaluate them on a regular cadence; **mine** the durable learnings out (into code, ADRs,
+  `AGENT_LEARNINGS.md`, rules) and then **prune** the artifact. The durable SOT is git history + code +
+  ADRs + learnings + rules — not the arc scaffolding. Compression is the anti-graveyard gate.
+
+## Non-blocked phase shape (structure every arc this way)
+
+- **Phase A (agent-only):** front-load EVERY agent-runnable slice; never interleave owner-gated items
+  mid-sequence. **Pre-stage every gate during Phase A** (migration SQL PR'd-but-unapplied, remediation
+  scripts, dry-run reports) so a gate becomes an approval, not a work session.
+- **Phase B (ONE owner sitting):** batch all gates — migrations, DB mutations, secrets, spend, merge —
+  into a single pre-staged checkpoint.
+- **Phase C (activation):** agent resumes — verify, activate gated features, e2e, deploy, report.
+- **Decide-by-default:** every open decision carries a recommended default; proceed unattended; the
+  owner overrides at the checkpoint. In hands-off mode this **overrides** core-principles' "when in
+  doubt, STOP, ask the user" — proceed under the safe default and **park** the decision for the owner
+  rather than blocking. Escalate mid-run ONLY when a decision has **no safe default** or the action is
+  **irreversible/destructive** (delete, DB mutation, spend, deploy, force-push). **Done-when per item:**
+  each item states its own verification. **Build-behind-gate:** ship data-dependent features dormant;
+  they activate when the data lands.
+
+## Quality gates (always)
+
+- Run the **exact CI gate locally, whole, before pushing** (the repo's `make check` / `npm run
+  validate` — format + lint + type + test + build). Never à la carte. Run the **audit/security target**
+  too (`npm audit` / dependency + secret scan).
+- **Strict TDD, RED first** — model the desired behavior and observe the red before implementing.
+  Modules only; rendering/wiring/glue/config are covered by build + lint + e2e, never unit tests. Only
+  value-add tests; never chase coverage.
+- Assume **strict lint + typing + security always**, on every file, whether or not it has unit tests.
+
+## Verification (verdict-is-the-status)
+
+- Verify on the **live target**, not mocks or localhost assumptions — run e2e against **local AND the
+  remote deploy**. `curl` can lie where the browser fails (per-encoding cache variants).
+- UI e2e uses **patchright/Chromium**: vary viewport + device, rotate portrait AND landscape, click
+  every control, capture **screenshots (and read 2-3 of them)** + opt-in video. **App console errors
+  fail the run**; capture failed network requests.
+- **Never trust a verification started before the edge settles** after a deploy (add a settle wait +
+  asset-hash/MIME poll). Commit a **run manifest** (append PASS/FAIL honestly, keep FAILs). Prefer a
+  **scheduled remote monitor** that auto-opens/updates an alert issue on FAIL.
+
+## Durability + the unattended tax (hard rules)
+
+- **git is the only durable SOT** — a session/container death loses anything uncommitted. For long runs
+  use **resume-from-run-id** (replays cached agent calls, re-runs only the tail); commit-as-you-go.
+- Prefix EVERY `git`/`gh` with `env -u GH_TOKEN -u GITHUB_TOKEN` (both vars shadow the real credential
+  -> 403 on writes). Commit with `--no-gpg-sign` and `-F <file>` (never `-m` — backticks/`$()` in `-m`
+  get shell-substituted). For rebase, disable signing (`-c commit.gpgsign=false`).
+- **Merge is an owner gate.** Open the PR, drive the gate to green, then **park for owner approval** —
+  never agent auto-merge. `--admin` bypasses ONLY the signature gate, never a failing/absent check;
+  **never relax branch protection**. Clear a stuck required check by updating the branch to `main`, not
+  by nudge-commits.
+- **Scraper / untrusted-input repos: keep the Bash allowlist narrow** — broad read-only Bash widens
+  prompt-injection blast radius and can read secrets. Prefer `Read`/`Grep`/`Glob` (never gated) +
+  `uv run python` one-liners over `cat`/`grep`.
+- **Compact at phase/milestone boundaries.** The model cannot self-trigger `/compact`; set
+  `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, a `PreCompact` archive hook (flush the live arc state before the
+  summary lands), and a `SessionStart:compact` re-onboard hook (see the settings template). **Subagent
+  discovery** to keep dumps out of the window — the biggest lever. Durable facts belong in
+  plan/handoff/memory, not only in-conversation.

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -10,3 +10,9 @@
 https://www\.fcc\.gov/engineering-technology/laboratory-division/general/equipment-authorization
 https://insta\.rs
 https://www\.awwwards\.com
+
+# Forward-reference to the qte77 estate unattended-execution guide (the MECHANISM
+# deploys here; the depth guide stays in the contract repo). Resolves once qte77
+# commits its arc-003 contract — the same gate this parked kit waits on. The
+# always-loaded rule + templates repoint to this canonical location.
+https://github\.com/qte77/qte77/blob/main/docs/unattended-execution\.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **workspace-setup** (1.5.0): unattended-run kit added to the deployed set — `unattended-execution`
+  always-loaded rule (→ `.claude/rules/`) plus `plan.template.md`, `handoff.template.md`, and
+  `settings.unattended.jsonc` (→ `docs/templates/`) so scaffolded repos inherit the hands-off contract.
+  Pre-stages the qte77 arc-003 estate contract (still uncommitted); the guide stays in the contract repo
+  and the rule/templates repoint to its canonical location (#197)
 - **security-audit** (1.2.0): `triaging-security-report` skill — verify an external/AI-generated
   security report against the actual code before acting; four-way verdict rubric
   (CONFIRMED / OVERSTATED / FALSE-POSITIVE / FABRICATED), deployment-context severity re-rating,

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ check_sync:  ## Verify all copies are in sync with .claude/ SoT
 	@test -L plugins/workspace-setup/rules/core-principles.md || (echo "ERROR: plugins/workspace-setup/rules/core-principles.md is not a symlink" && exit 1)
 	@test -L plugins/workspace-setup/rules/context-management.md || (echo "ERROR: plugins/workspace-setup/rules/context-management.md is not a symlink" && exit 1)
 	@test -L plugins/workspace-setup/rules/compound-learning.md || (echo "ERROR: plugins/workspace-setup/rules/compound-learning.md is not a symlink" && exit 1)
+	@test -L plugins/workspace-setup/rules/unattended-execution.md || (echo "ERROR: plugins/workspace-setup/rules/unattended-execution.md is not a symlink" && exit 1)
 	@test -L plugins/workspace-sandbox/rules/core-principles.md || (echo "ERROR: plugins/workspace-sandbox/rules/core-principles.md is not a symlink" && exit 1)
 	@test -L plugins/workspace-sandbox/rules/context-management.md || (echo "ERROR: plugins/workspace-sandbox/rules/context-management.md is not a symlink" && exit 1)
 	@test -L plugins/workspace-sandbox/rules/compound-learning.md || (echo "ERROR: plugins/workspace-sandbox/rules/compound-learning.md is not a symlink" && exit 1)

--- a/lychee.toml
+++ b/lychee.toml
@@ -16,5 +16,6 @@ accept = [200, 202, 204, 301, 401, 403, 429]
 exclude_path = [
   "plugins/docs-governance/templates",
   "plugins/workspace-setup/governance",
+  "plugins/workspace-setup/templates",
   "plugins/workspace-sandbox/governance",
 ]

--- a/plugins/workspace-setup/.claude-plugin/plugin.json
+++ b/plugins/workspace-setup/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workspace-setup",
-  "version": "1.4.1",
-  "description": "Deploys workspace rules, statusline, governance files, base settings, and read-once deduplication hook",
+  "version": "1.5.0",
+  "description": "Deploys workspace rules, statusline, governance files, base settings, unattended-run templates, and read-once deduplication hook",
   "author": { "name": "Claude Code Utils Contributors" },
   "keywords": ["workspace", "settings", "rules", "statusline", "governance", "setup", "read-once"]
 }

--- a/plugins/workspace-setup/README.md
+++ b/plugins/workspace-setup/README.md
@@ -6,7 +6,7 @@ Self-contained — all CC-specific files bundled in the plugin, no external depe
 
 ## Deployed files
 
-- **rules/*.md** → `.claude/rules/` — core principles, context management
+- **rules/*.md** → `.claude/rules/` — core principles, context management, compound learning, unattended execution
 - **scripts/statusline.sh** → `.claude/scripts/` — status line display. World clock off by default. Two ways to opt in: (1) **persistent** — set `CC_WORLD_CLOCK="Asia/Tokyo,Europe/Paris,Europe/London,UTC,America/New_York,America/Los_Angeles"` in your shell rc (needs CC restart to change); (2) **live toggle** — write the same comma-separated zone list to `~/.claude/world-clock` (next prompt render picks it up; `rm` the file to turn off). Env var wins over file. Use east-to-west / sunrise order or any IANA zones you prefer. Each entry is either a bare zone (`Europe/Paris` → label `Paris`) or `Zone=Label` to override the rendered label (`America/New_York=NYC` → label `NYC`). Zones render on a dedicated line below the main statusline; invalid zones show as `?<name>`. See the comment block at the top of `.claude/scripts/statusline.sh` for the curated shortlist and usage notes.
 - **settings/settings-base.json** → `.claude/settings.json` — lightweight defaults (statusline, context7, attribution)
 - **governance/AGENTS.md** → `AGENTS.md` — agent behavioral rules and decision framework
@@ -14,6 +14,7 @@ Self-contained — all CC-specific files bundled in the plugin, no external depe
 - **governance/AGENT_REQUESTS.md** → `AGENT_REQUESTS.md` — human escalation protocol
 - **governance/README.md** → `README.md` — value-first front door, derived from the [qte77 doc-structure canon](https://github.com/qte77/qte77/blob/main/docs/doc-structure.md)
 - **governance/CONTRIBUTING.md** → `CONTRIBUTING.md` — technical workflows + the `## Documentation hierarchy` statement
+- **templates/*** → `docs/templates/` — copyable references for hands-off runs: `plan.template.md` + `handoff.template.md` (per-arc plan/handoff scaffolds with the `file:line` source map) and `settings.unattended.jsonc` (the auto-compact + PreCompact/SessionStart harness snippet to merge into `.claude/settings.json`). Instantiates the [qte77 unattended-execution contract](https://github.com/qte77/qte77/blob/main/docs/unattended-execution.md).
 
 All files use copy-if-not-exists (won't overwrite).
 

--- a/plugins/workspace-setup/hooks/scripts/setup-workspace.sh
+++ b/plugins/workspace-setup/hooks/scripts/setup-workspace.sh
@@ -40,7 +40,18 @@ for file in "$PLUGIN_DIR/governance/"*.md; do
   fi
 done
 
-# 5. Report
+# 5. Templates → docs/templates/ (copyable references: plan/handoff + unattended settings snippet)
+mkdir -p docs/templates
+for tmpl in "$PLUGIN_DIR/templates/"*; do
+  [ -f "$tmpl" ] || continue
+  target="docs/templates/$(basename "$tmpl")"
+  if [ ! -f "$target" ]; then
+    cp "$tmpl" "$target"
+    DEPLOYED+=("template: $(basename "$tmpl")")
+  fi
+done
+
+# 6. Report
 if [ ${#DEPLOYED[@]} -gt 0 ]; then
   echo "# Workspace Setup"
   echo ""

--- a/plugins/workspace-setup/rules/unattended-execution.md
+++ b/plugins/workspace-setup/rules/unattended-execution.md
@@ -1,0 +1,1 @@
+../../../.claude/rules/unattended-execution.md

--- a/plugins/workspace-setup/templates/handoff.template.md
+++ b/plugins/workspace-setup/templates/handoff.template.md
@@ -1,0 +1,62 @@
+---
+plan: ../plans/NNN-slug.md
+status: <not started | in progress — resume at X | shipped>
+updated: YYYY-MM-DD
+---
+
+# Handoff — <Title>
+
+Onboarding for the next session. Full detail + `file:line` source map:
+[plan NNN](../plans/NNN-slug.md). **Read the plan's source map first — you should not need to
+re-explore.** Tracking issue: <#NNN>.
+
+> Delete this callout before use. Instantiates the estate
+> [unattended-execution contract](https://github.com/qte77/qte77/blob/main/docs/unattended-execution.md). The handoff is read FIRST, the plan
+> second. Keep it in sync with the plan + `MEMORY.md` at every milestone.
+
+## State at handoff (YYYY-MM-DD)
+
+- **Branch / sync:** <branch, clean or dirty, ahead/behind main>.
+- **Prod:** <live version, deploy state, last remote e2e result e.g. 111/111>.
+- **Shipped this arc:** <merged PR numbers + one-liners>.
+- **Resume point:** <the single NEXT action>.
+- **Owner action that unblocks the rest:** <the one pre-staged Phase B gate, if any>.
+
+## How to handle the plan (order)
+
+<Numbered, ordered steps. What to build first and WHY (usually the backend/data slice that reaches
+green now and unblocks the rest). Explicit "do NOT start X first".>
+
+## First actions on resume
+
+- <The literal first commands/edits — branch name, files to touch, tests to write red.>
+
+## Working style
+
+- **Strict TDD, RED first** — model the expected behavior red, then green. Modules only; glue/config/CSS
+  and one-shot scripts are covered by build + lint + e2e, never unit tests. Value-add tests only.
+- **Run the whole gate == CI** (`make check` / `npm run validate`) + the audit target before pushing.
+  Strict lint + type + security on every file.
+- **Merge is an owner gate** — park the green PR for approval; never auto squash-merge.
+
+## Owner-gates (pre-staged; batch into one sitting)
+
+<Each gate: what is pre-staged in Phase A, and the single switch the owner flips in Phase B.>
+
+## Gotchas (the unattended tax + arc-specific traps)
+
+- Prefix every `git`/`gh` with `env -u GH_TOKEN -u GITHUB_TOKEN`; commit `--no-gpg-sign` and `-F` (not
+  `-m`). See the [unattended tax](https://github.com/qte77/qte77/blob/main/docs/unattended-execution.md#the-unattended-tax) for the full list.
+- **Verify on the live target** (local + remote); edge-settle before the remote sweep; console errors
+  fail the run; read 2-3 screenshots.
+- Cross-repo: delegate content edits to a subagent inside the target repo; the main agent does git
+  plumbing only.
+- <Arc-specific verified traps — the "these WILL bite you" list carried forward so the next session
+  does not rediscover them.>
+
+## At arc close (mine, then prune)
+
+This handoff, its plan, the findings, and the arc's memory are **ephemeral working state**. When the arc
+ships: **mine** them — promote durable learnings to `AGENT_LEARNINGS.md` / a rule / an ADR, and the
+*why* into commit bodies — migrate any remainder to the next `NNN`, then **prune** this scaffolding. Do
+not leave shipped arcs as permanent docs.

--- a/plugins/workspace-setup/templates/plan.template.md
+++ b/plugins/workspace-setup/templates/plan.template.md
@@ -1,0 +1,72 @@
+---
+status: proposed — not started
+phase: <which phase is the recommended first build>
+handoff: ../handoffs/NNN-slug.md
+updated: YYYY-MM-DD
+---
+
+# <Title — what this arc delivers>
+
+<One paragraph: the change, and that this doc is the source map so a fresh session executes without
+re-exploring. Point to the paired handoff for onboarding + how-to-run.>
+
+> Delete this callout before use. This template instantiates the estate
+> [unattended-execution contract](https://github.com/qte77/qte77/blob/main/docs/unattended-execution.md). Keep the `file:line` source map — it is
+> what lets a cold or compacted session act without re-mapping. Match the repo's digit width for `NNN`.
+
+## Why
+
+<2-4 lines: incumbent state -> the gap -> what this arc changes. Link specs, do not inline them.>
+
+## Repo + role map
+
+<Only for cross-repo arcs; drop for single-repo. Local path | GitHub | Role. Restate estate git
+conventions once: `env -u GH_TOKEN -u GITHUB_TOKEN`; `--no-gpg-sign`; branch per topic; merge is an
+owner gate.>
+
+## Owner decisions (locked, YYYY-MM-DD)
+
+<Decisions already made — the agent does NOT re-litigate these. Each with a one-line rationale.>
+
+## Decide-by-default (apply silently unless the owner overrides at the Phase B checkpoint)
+
+<Every OPEN decision with its recommended default, so the run proceeds unattended.>
+
+## Source map — touch without re-mapping (verified YYYY-MM-DD, file:line)
+
+<The load-bearing section. One table per subsystem/repo.>
+
+| File | Symbols / content | Role in this arc |
+| --- | --- | --- |
+| `path/to/file.py` | `func_name` (signature), line ~NN | what changes here |
+
+## Phase plan (non-blocked A/B/C)
+
+- **Phase A — agent-only.** <Front-loaded slices, in order. Split independent tails to run in parallel.
+  Pre-stage every Phase B gate here (migration SQL PR'd-but-unapplied, scripts, dry-runs).>
+- **Phase B — one owner sitting.** <Every gate, batched: migrations, DB mutations, secrets, spend,
+  merge. Each item names the exact owner action + the pre-staged artifact that makes it an approval.>
+- **Phase C — activation.** <Verify gated features, e2e local + remote, deploy + probe, report, close.>
+
+## Backlog (each item states its done-when)
+
+- [ ] **<Item>** — <what> — *done-when:* <the exact self-verification>. <MODULE (RED-first) or glue->e2e.>
+
+## Owner-gates (the only things that block hands-off)
+
+<Enumerate: migration apply, secret set, service-role/scoped-key mint, deploy, spend, merge. For each:
+what is pre-staged, and the single switch the owner flips.>
+
+## Verification
+
+<The gate command (`make check` / `npm run validate` == CI, run whole) + the audit target. The e2e
+sweep command (local AND remote), the console-error-fail expectation, expected pass counts as
+regression sentinels, and the run-manifest path.>
+
+## Open questions
+
+<Genuinely unresolved — distinct from decide-by-default. Each with the trade-off.>
+
+## Refs
+
+<Tracking issue; related plans/ADRs; external blueprints. Links only.>

--- a/plugins/workspace-setup/templates/settings.unattended.jsonc
+++ b/plugins/workspace-setup/templates/settings.unattended.jsonc
@@ -1,0 +1,61 @@
+// Unattended-run harness config — MERGE these keys into a repo's .claude/settings.json.
+// This is a copyable template, not a live settings file (JSONC comments are for humans; strip them,
+// settings.json is strict JSON). Instantiates the estate unattended-execution contract:
+//   https://github.com/qte77/qte77/blob/main/docs/unattended-execution.md  ->  "Context economy".
+//
+// Learned from prior runs: few repos had this wired, and the ones that did not wall-clocked into
+// hard context limits mid-arc. Make it standard for any repo running hands-off.
+{
+  "env": {
+    // Fire auto-compact earlier (main + subagents) so a long run never wall-clocks into a hard
+    // context limit mid-arc. 50 = compact at 50% capacity; leaves room for reasoning + recovery
+    // (see .claude/rules/context-management.md, the 40-60% target). The model cannot self-trigger
+    // /compact — this env var is how you make compaction happen unattended.
+    //
+    // Reading the statusline with this set: a "free %" figure is a COUNTDOWN TO AUTO-COMPACTION, not to
+    // the hard context limit. At 50, ~0% "free" means the window is ~50% used and compaction is at its
+    // threshold — by design here, not an error. (/context shows the other denominator: fraction of the
+    // full window used.)
+    //
+    // Threshold tradeoff: 50 is aggressive — it fires often and can fire mid-task. ~65-70 gives more
+    // runway while still leaving recovery room. Tune per repo, and lean on milestone-flushing (the
+    // durable ledger) so the exact trigger point matters less. Subagent your discovery FIRST — the
+    // biggest lever, and it pushes the trigger point out on its own.
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50"
+  },
+
+  "hooks": {
+    // Highest-ROI compaction change: archive a rich handoff to disk BEFORE the summary replaces the
+    // window. A PreCompact hook can archive (and gate) but never itself triggers compaction — so it
+    // turns a compaction from a loss into a checkpoint. Point it at a tracked script that flushes the
+    // live arc state (shipped list, one-step resume, branch/PR/CI, parked gates) to handoff + memory.
+    "PreCompact": [
+      {
+        "matcher": "auto",
+        "hooks": [
+          { "type": "command", "command": ".claude/scripts/archive-handoff.sh" }
+        ]
+      }
+    ],
+
+    // Re-onboard the agent after a compaction (and at session start) so the post-compact context is
+    // correct, not just smaller. Point the command at a repo script that echoes the re-onboarding
+    // instruction; keep the instruction itself in the script so it stays in git.
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            // Example inline form. Prefer a tracked script: .claude/scripts/reonboard.sh
+            "command": "echo 'Re-onboard: re-read the newest docs/handoffs/NNN + its paired plan (the file:line source map). Verify plan + handoff + MEMORY.md reflect current branch/PR/CI state. Keep conclusions and the parked owner-gates; drop raw command output and search dumps.'"
+          }
+        ]
+      }
+    ]
+  }
+
+  // Permissions: grow .claude/settings.local.json as an allowlist from real runs (the friction-remover
+  // for true hands-off). For scraper / untrusted-input repos keep it NARROW — broad read-only Bash
+  // widens prompt-injection blast radius. See https://github.com/qte77/qte77/blob/main/docs/unattended-execution.md "The unattended tax".
+}


### PR DESCRIPTION
## PARKED — do NOT merge until the qte77 arc-003 contract commits

Pre-stages the estate **unattended-run kit** into the `workspace-setup` plugin's deployed set so new/scaffolded repos inherit it. Derives from qte77's **still-uncommitted arc 003 draft** — this PR must stay parked until that contract lands.

### What ships
Extends `workspace-setup`'s SessionStart deploy (`hooks/scripts/setup-workspace.sh`) following the existing copy-if-not-exists convention:

- **`unattended-execution` rule → `.claude/rules/`** — vendored into the repo rule SoT (`.claude/rules/unattended-execution.md`) and symlinked into the plugin exactly like `core-principles` / `context-management` / `compound-learning`; the existing `rules/*.md` glob deploys it. `make check_sync` gets a matching symlink assertion.
- **`plan.template.md`, `handoff.template.md`, `settings.unattended.jsonc` → `docs/templates/`** — new deploy step; kept together as the qte77 canon lays them out. Settings stays valid **JSONC** (a merge snippet, not a live settings file).

The MECHANISM depth guide (`docs/unattended-execution.md`) is **deliberately NOT deployed** per the estate META→MECHANISM split (it stays in the contract repo, qte77).

### Dangling-link handling
The rule + templates originally link to `docs/unattended-execution.md`, which would dangle in a target repo. Repointed that one guide link to its **canonical qte77 location** (`https://github.com/qte77/qte77/blob/main/docs/unattended-execution.md`) — following workspace-setup's existing "point at the qte77 canon" convention (same pattern the docs-governance derived templates use). The templates dir is excluded wholesale in `lychee.toml` (skeleton forward-refs, matching the `governance/` precedent); the qte77 guide URL is added to `.lycheeignore` as a forward-reference that resolves once the contract lands.

### Why do-not-merge
The canonical guide URL only resolves after qte77 commits arc 003 (rule + guide + 3 templates are all currently uncommitted upstream). Merging before then ships a link that 404s. **Merge gate = the qte77 contract commit.**

### Verify (run locally)
- `make validate` — PASS (plugin structure + JSON syntax)
- `make check_sync` — PASS (incl. the new symlink assertion + canon drift)
- `settings.unattended.jsonc` valid JSONC; `setup-workspace.sh` `bash -n` clean; simulated deploy lands all 14 files at expected paths
- `lychee` on the rule + README — 0 errors (guide URL excluded)
- Version bumped `workspace-setup` 1.4.1 → 1.5.0 in both `plugin.json` and `marketplace.json` (required by `check-plugin-versions`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
